### PR TITLE
Add dry-view integration through an extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,12 @@ GEM
       dry-equalizer (~> 0.2, >= 0.2.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0)
+    dry-view (0.7.0)
+      dry-configurable (~> 0.1)
+      dry-core (~> 0.2)
+      dry-equalizer (~> 0.2)
+      dry-inflector (~> 0.1)
+      tilt (~> 2.0, >= 2.0.6)
     ice_nine (0.11.2)
     method_source (0.9.2)
     pry (0.12.2)
@@ -72,6 +78,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    tilt (2.0.9)
     yard (0.9.19)
 
 PLATFORMS
@@ -79,6 +86,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
+  dry-view (~> 0.7)
   pry-byebug
   rack-test (~> 1.1)
   rake (~> 10.0)

--- a/README.md
+++ b/README.md
@@ -262,6 +262,16 @@ op_2 = ->(conn) { conn.set_response_body('Hello') }
 WebPipe::App.new([op_1, op_2])
 ```
 
+## Extensions
+
+By default, `web_pipe` behavior is the very minimal you need to build
+a web application. However, you can extend it with the following
+extensions (click on each name for details on the usage):
+
+- [dry-view](lib/web_pipe/extensions/dry_view/dry_view.rb):
+  Integration with [`dry-view`](https://dry-rb.org/gems/dry-view/)
+  rendering system.
+
 ## Current status
 
 `web_pipe` is in active development. The very basic features to build

--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -4,6 +4,8 @@ require 'web_pipe/dsl/builder'
 # README](https://github.com/waiting-for-dev/web_pipe/blob/master/README.md)
 # for a general overview of this library.
 module WebPipe
+  extend Dry::Core::Extensions
+
   # Including just delegates to an instance of `Builder`, so
   # `Builder#included` is finally called.
   def self.included(klass)
@@ -12,5 +14,9 @@ module WebPipe
 
   def self.call(*args)
     DSL::Builder.new(*args)
+  end
+
+  register_extension :dry_view do
+    require 'web_pipe/extensions/dry_view/dry_view'
   end
 end

--- a/lib/web_pipe/extensions/dry_view/dry_view.rb
+++ b/lib/web_pipe/extensions/dry_view/dry_view.rb
@@ -1,0 +1,41 @@
+module WebPipe
+  # Integration with `dry-view` rendering system.
+  #
+  # This extensions adds a {#view} method to {WebPipe::Conn} which
+  # sets the string output of a `dry-view` view as response body.
+  #
+  # @example
+  #   WebPipe.load_extensions(:dry_view)
+  #
+  #   class SayHelloView < Dry::View
+  #     config.paths = [File.join(__dir__, '..', 'templates')]
+  #     config.template = 'say_hello'
+  #
+  #     expose :name
+  #   end
+  #     
+  #   class App
+  #     include WebPipe
+  #
+  #     plug :render
+  #
+  #     def render(conn)
+  #       conn.view(SayHello.new, name: 'Joe')
+  #     end
+  #   end
+  #   
+  # @see https://dry-rb.org/gems/dry-view/
+  class Conn < Dry::Struct
+    # Sets string output of a view as response body.
+    #
+    # @param view_instance [Dry::View]
+    # @param kwargs [Hash] Arguments to pass along to `Dry::View#call`
+    #
+    # @return WebPipe::Conn
+    def view(view_instance, **kwargs)
+      set_response_body(
+        view_instance.call(**kwargs).to_str
+      )
+    end
+  end
+end

--- a/spec/extensions/dry_view/fixtures/template_with_input.html.str
+++ b/spec/extensions/dry_view/fixtures/template_with_input.html.str
@@ -1,0 +1,1 @@
+Hello #{name}

--- a/spec/extensions/dry_view/fixtures/template_without_input.html.str
+++ b/spec/extensions/dry_view/fixtures/template_without_input.html.str
@@ -1,0 +1,1 @@
+Hello world

--- a/spec/extensions/dry_view/view_spec.rb
+++ b/spec/extensions/dry_view/view_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'support/env'
+require 'dry/view'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe 'WebPipe::Conn#view' do
+  before do
+    WebPipe.load_extensions(:dry_view)
+  end
+
+  let(:view_class) do
+    Class.new(Dry::View) do
+      config.paths = [File.join(__dir__, 'fixtures')]
+    end
+  end
+
+  it 'sets Rendered string serialization as response body' do
+    view = Class.new(view_class) do
+      config.template = 'template_without_input'
+    end
+    conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+
+    new_conn = conn.view(view.new)
+
+    expect(new_conn.response_body).to eq(['Hello world'])
+  end
+
+  it "passes kwargs along as view's call arguments" do
+    view = Class.new(view_class) do
+      config.template = 'template_with_input'
+
+      expose :name
+    end
+    conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+
+    new_conn = conn.view(view.new, name: 'Joe')
+
+    expect(new_conn.response_body).to eq(['Hello Joe'])
+  end
+end

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.9"
   spec.add_development_dependency "redcarpet", "~> 3.4"
   spec.add_development_dependency "pry-byebug"
+  spec.add_development_dependency "dry-view", "~> 0.7"
 end


### PR DESCRIPTION
Example:

```ruby
WebPipe.load_extensions(:dry_view)

class SayHelloView < Dry::View
  config.paths = [File.join(__dir__, '..', 'templates')]
  config.template = 'say_hello'

  expose :name
end
  
class App
  include WebPipe

  plug :render

  def render(conn)
    conn.view(SayHello.new, name: 'Joe')
  end
end
```