### PR TITLE
Add container extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     web_pipe (0.1.0)
+      dry-configurable (~> 0.8)
       dry-initializer (~> 3.0)
       dry-monads (~> 1.2)
       dry-struct (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ extensions (click on each name for details on the usage):
 - [dry-view](lib/web_pipe/extensions/dry_view/dry_view.rb):
   Integration with [`dry-view`](https://dry-rb.org/gems/dry-view/)
   rendering system.
+- [container](lib/web_pipe/extensions/container/container.rb): Allows
+  configuring a container to resolve dependencies from
+  `WebPipe::Conn`.
 
 ## Current status
 

--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -19,4 +19,8 @@ module WebPipe
   register_extension :dry_view do
     require 'web_pipe/extensions/dry_view/dry_view'
   end
+
+  register_extension :container do
+    require 'web_pipe/extensions/container/container'
+  end
 end

--- a/lib/web_pipe/conn.rb
+++ b/lib/web_pipe/conn.rb
@@ -1,4 +1,5 @@
 require 'dry/struct'
+require 'dry/configurable'
 require 'web_pipe/conn_support/types'
 require 'web_pipe/conn_support/errors'
 require 'web_pipe/conn_support/headers'
@@ -30,6 +31,7 @@ module WebPipe
   #     taint
   class Conn < Dry::Struct
     include ConnSupport::Types
+    extend Dry::Configurable
 
     # @!attribute [r] env
     #

--- a/lib/web_pipe/extensions/container/container.rb
+++ b/lib/web_pipe/extensions/container/container.rb
@@ -1,0 +1,25 @@
+module WebPipe
+  # Adds a `container` setting to {WebPipe::Conn} configuration.
+  #
+  # Besides the setting, a `.container` reader attribute is added to
+  # {WebPipe::Conn}.
+  #
+  # This extension is meant to be a building block for other
+  # extensions.
+  #
+  # @example
+  #   WebPipe.load_extensions(:container)
+  #
+  #   Container = {'foo' => 'bar'}.freeze
+  #
+  #   WebPipe.config.container = Container
+  #   WebPipe.container['foo'] # => 'bar'
+  class Conn < Dry::Struct
+    # Container with nothing registered.
+    EMPTY_CONTAINER = {}.freeze
+
+    setting(:container, EMPTY_CONTAINER, reader: true) do |c|
+      Types::Container[c]
+    end
+  end
+end

--- a/spec/extensions/container/container_spec.rb
+++ b/spec/extensions/container/container_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn'
+
+RSpec.describe WebPipe::Conn do
+  before do
+    WebPipe.load_extensions(:container)
+  end
+
+  let(:container) { {'foo' => 'bar'}.freeze }
+
+  before { WebPipe::Conn.config.container = container }
+
+  describe '#config' do
+    it "has a 'container' setting" do
+      expect(WebPipe::Conn.config.container).to be(container)
+    end
+  end
+
+  it "has a 'container' reader" do
+    expect(WebPipe::Conn.container).to be(container)
+  end
+end

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-types", "~> 1.1"
   spec.add_runtime_dependency "dry-struct", "~> 1.0"
   spec.add_runtime_dependency "dry-initializer", "~> 3.0"
+  spec.add_runtime_dependency "dry-configurable", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Adds a `container` setting to `WebPipe::Conn` configuration.

Besides the setting, a `.container` reader attribute is added to it.

This extension is meant to be a building block for other
extensions.

```ruby
WebPipe.load_extensions(:container)

Container = {'foo' => 'bar'}.freeze

WebPipe.config.container = Container
WebPipe.container['foo'] # => 'bar'
```