### PR TITLE
Take view context from the bag and help with a plug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     web_pipe (0.1.0)
-      dry-configurable (~> 0.8)
       dry-initializer (~> 3.0)
       dry-monads (~> 1.2)
       dry-struct (~> 1.0)

--- a/lib/web_pipe/conn.rb
+++ b/lib/web_pipe/conn.rb
@@ -1,5 +1,5 @@
 require 'dry/struct'
-require 'dry/configurable'
+require 'web_pipe/types'
 require 'web_pipe/conn_support/types'
 require 'web_pipe/conn_support/errors'
 require 'web_pipe/conn_support/headers'
@@ -31,7 +31,6 @@ module WebPipe
   #     taint
   class Conn < Dry::Struct
     include ConnSupport::Types
-    extend Dry::Configurable
 
     # @!attribute [r] env
     #
@@ -343,7 +342,9 @@ module WebPipe
     #
     # @raise ConnSupport::KeyNotFoundInBagError when key is not
     # registered in the bag.
-    def fetch(key)
+    def fetch(key, default = Types::Undefined)
+      return bag.fetch(key, default) unless default == Types::Undefined
+
       bag.fetch(key) { raise ConnSupport::KeyNotFoundInBagError.new(key) }
     end
 

--- a/lib/web_pipe/extensions/dry_view/dry_view.rb
+++ b/lib/web_pipe/extensions/dry_view/dry_view.rb
@@ -87,6 +87,17 @@ module WebPipe
   #       # will be available in the view scope
   #     end
   #   end
+  #
+  # It can be streamline using {WebPipe::Plugs::ViewContext} plug,
+  # which accepts a callable object which should return the request
+  # context from given {WebPipe::Conn}:
+  #
+  # @example
+  #  # ...
+  #    plug :set_view_context, WebPipe::Plugs::ViewContext[
+  #                              ->(conn) { { current_path: conn.full_path } }
+  #                            ]
+  #  # ...
   #   
   # @see https://dry-rb.org/gems/dry-view/
   class Conn < Dry::Struct

--- a/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
+++ b/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
@@ -1,0 +1,38 @@
+require 'web_pipe/types'
+require 'web_pipe/extensions/dry_view/dry_view'
+
+module WebPipe
+  module Plugs
+    # Calls object with conn and puts the result into bag's `:view_context`.
+    #
+    # This is meant to contain a Proc which will be called with the same
+    # {WebPipe::Conn} instance of the operation. It must return
+    # request specific view context as a hash. Ultimately, this will
+    # be provided to {Dry::View::Context#with} before passing the
+    # result along to the view instance.
+    #
+    # @example
+    #   class App
+    #     include WebPipe
+    #
+    #     ViewContext = (conn) -> { { current_path: conn.full_path } }
+    #
+    #     plug :view_context, with: WebPipe::Plugs::ViewContext[ViewContext]
+    #     plug :render
+    #
+    #     def render
+    #       view(MyView.new)
+    #     end
+    #   end
+    #
+    # @see WebPipe::Conn#view
+    module ViewContext
+      def self.[](view_context_proc)
+        Types.Interface(:call)[view_context_proc]
+        lambda do |conn|
+          conn.put(Conn::VIEW_CONTEXT_KEY, view_context_proc.(conn))
+        end
+      end
+    end
+  end
+end

--- a/lib/web_pipe/types.rb
+++ b/lib/web_pipe/types.rb
@@ -1,9 +1,11 @@
 require 'dry/types'
+require 'dry/core/constants'
 
 module WebPipe
   # Namespace for generic library types.
   module Types
     include Dry.Types()
+    include Dry::Core::Constants
 
     Container = Interface(:[])
   end

--- a/spec/extensions/dry_view/plugs/view_context_spec.rb
+++ b/spec/extensions/dry_view/plugs/view_context_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn_support/builder'
+require 'web_pipe'
+require 'web_pipe/extensions/dry_view/plugs/view_context'
+
+RSpec.describe WebPipe::Plugs::ViewContext do
+  before do
+    WebPipe.load_extensions(:dry_view)
+  end
+
+  describe '.[]' do
+    it "creates an operation which calls given proc with conn and sets result into bag's view_context key" do
+      conn = WebPipe::ConnSupport::Builder.
+               call(DEFAULT_ENV).
+               put(:foo, 'bar')
+      view_context_proc = ->(conn) { { foo: conn.fetch(:foo) } }
+      plug = described_class[view_context_proc]
+
+      new_conn = plug.(conn)
+
+      expect(new_conn.fetch(WebPipe::Conn::VIEW_CONTEXT_KEY)).to eq({ foo: 'bar' })
+    end
+  end
+end

--- a/spec/unit/web_pipe/conn_spec.rb
+++ b/spec/unit/web_pipe/conn_spec.rb
@@ -148,6 +148,12 @@ RSpec.describe WebPipe::Conn do
         conn.fetch(:foo)
       }.to raise_error(WebPipe::ConnSupport::KeyNotFoundInBagError)
     end
+
+    it 'returns default when it is given and key does not exist' do
+      conn = build(DEFAULT_ENV)
+
+      expect(conn.fetch(:foo, :bar)).to be(:bar)
+    end
   end
 
   describe 'put' do

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-types", "~> 1.1"
   spec.add_runtime_dependency "dry-struct", "~> 1.0"
   spec.add_runtime_dependency "dry-initializer", "~> 3.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Instead of configuring at the class level, now the `view_context` to be injected with `Dry::Context::with` is taken from a `:view_context` key in the bag.

`Plugs::ViewContext` creates an operation which automatically assigns the view context calling given Proc with the `Conn` at the moment of execution.