### PR TITLE
Plug to set Content-Type response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ advantage in order to build your application:
 
 - [container](lib/web_pipe/plugs/container.rb): Allows
   configuring a container to resolve dependencies.
+- [content_type](lib/web_pipe/plugs/content_type.rb): Sets
+  `Content-Type` response header.
 
 ## Extensions
 

--- a/lib/web_pipe/plugs/content_type.rb
+++ b/lib/web_pipe/plugs/content_type.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'web_pipe/types'
+
+module WebPipe
+  module Plugs
+    # Sets `Content-Type` response header.
+    #
+    # @example
+    #   class App
+    #     include WebPipe
+    #
+    #     plug :html, with: WebPipe::Plugs::ContentType['text/html']
+    #   end
+    module ContentType
+      # Content-Type header
+      HEADER = 'Content-Type'
+
+      def self.[](content_type)
+        ->(conn) { conn.add_response_header(HEADER, content_type) }
+      end
+    end
+  end
+end

--- a/spec/unit/web_pipe/plugs/content_type_spec.rb
+++ b/spec/unit/web_pipe/plugs/content_type_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/plugs/content_type'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::Plugs::ContentType do
+  describe '.[]' do
+    it "creates an operation which adds given argument as Content-Type header" do
+      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      plug = described_class['text/html']
+
+      new_conn = plug.(conn)
+
+      expect(new_conn.response_headers['Content-Type']).to eq('text/html')
+    end
+  end
+end


### PR DESCRIPTION
```ruby
plug :html, with: WebPipe::Plugs::ContentType['text/html']
```