### PR TITLE
Add composition of WebPipe's

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    web_pipe (0.1.0)
+    web_pipe (0.2.0)
       dry-initializer (~> 3.0)
       dry-monads (~> 1.2)
       dry-struct (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -180,20 +180,20 @@ class App
 
 #### Proc (or anything responding to `#call`)
 
-Operations can also be defined inline, through the `with:` keyword, as
-anything that responds to `#call`, like a `Proc`:
+Operations can also be defined inline as anything that responds to
+`#call`, like a `Proc`:
 
 ```ruby
 class App
   include WebPipe
 
-  plug :hello, with: ->(conn) { conn }
+  plug :hello, ->(conn) { conn }
 end
 ```
 
 #### Container
 
-When `with:` is a `String` or a `Symbol`, it can be used as the key to
+When a `String` or a `Symbol` is given, it can be used as the key to
 resolve an operation from a container. A container is just anything
 responding to `#[]`.
 
@@ -207,7 +207,7 @@ class App
 
   include WebPipe.(container: Container)
 
-  plug :hello, with: 'plugs.hello'
+  plug :hello, 'plugs.hello'
 end
 ```
 
@@ -220,7 +220,7 @@ overriding those configured through `plug`:
 class App
   include WebPipe
 
-  plug :hello, with: ->(conn) { conn.set_response_body('Hello') }
+  plug :hello, ->(conn) { conn.set_response_body('Hello') }
 end
 
 run App.new(
@@ -243,7 +243,7 @@ class App
   use Middleware1
   use Middleware2, option_1: value_1
 
-  plug :hello, with: ->(conn) { conn }
+  plug :hello, ->(conn) { conn }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,45 @@ class App
 #### Proc (or anything responding to `#call`)
 
 Operations can also be defined inline as anything that responds to
-`#call`, like a `Proc`:
+`#call`, like a `Proc`, or also like a block:
 
 ```ruby
 class App
   include WebPipe
 
   plug :hello, ->(conn) { conn }
+  plug(:hello2) { |conn| conn }
+end
+```
+
+The representation of a `WebPipe` as a Proc is itself an operation
+accepting a `Conn` and returning a `Conn`: the composition of all its
+plugs. Therefore, it can be plugged to any other `WebPipe`:
+
+```ruby
+class HtmlApp
+  include WebPipe
+
+  plug :html
+
+  private
+
+  def html(conn)
+    conn.set_response_header('Content-Type', 'text/html')
+  end
+end
+
+class App
+  include WebPipe
+
+  plug :html, &HtmlApp.new
+  plug :body
+
+  private
+
+  def body(conn)
+     conn.set_response_body('Hello, world!')
+  end
 end
 ```
 

--- a/lib/web_pipe/conn_support/composition.rb
+++ b/lib/web_pipe/conn_support/composition.rb
@@ -1,0 +1,89 @@
+require 'dry/initializer'
+require 'dry/monads/result'
+require 'web_pipe/types'
+require 'web_pipe/conn'
+require 'dry/monads/result/extensions/either'
+
+Dry::Monads::Result.load_extensions(:either)
+
+module WebPipe
+  module ConnSupport
+    # Composition of a pipe of {Operation} on a {Conn}.
+    #
+    # It represents the composition of a series of functions which
+    # take a {Conn} as argument and return a {Conn}.
+    #
+    # However, {Conn} can itself be of two different types (subclasses
+    # of it): a {Conn::Clean} or a {Conn::Dirty}. On execution time,
+    # the composition is stopped whenever the stack is emptied or a
+    # {Conn::Dirty} is returned in any of the steps.
+    class Composition
+      # Type for an operation.
+      #
+      # It should be anything callable expecting a {Conn} and
+      # returning a {Conn}.
+      Operation = Types.Interface(:call)
+
+      # Error raised when an {Operation} returns something that is not
+      # a {Conn}.
+      class InvalidOperationResult < RuntimeError
+        # @param returned [Any] What was returned from the {Operation}
+        def initialize(returned)
+          super(
+            <<~eos
+            An operation returned +#{returned.inspect}+. To be valid,
+            an operation must return whether a
+            WebPipe::Conn::Clean or a WebPipe::Conn::Dirty.
+          eos
+          )
+        end
+      end
+
+      include Dry::Monads::Result::Mixin
+
+      include Dry::Initializer.define -> do
+        # @!attribute [r] operations
+        #   @return [Array<Operation[]>]
+        param :operations, type: Types.Array(Operation)
+      end
+
+      # @param conn [Conn]
+      # @return [Conn]
+      # @raise InvalidOperationResult when an operation does not
+      # return a {Conn}
+      def call(conn)
+        extract_result(
+          apply_operations(
+            conn
+          )
+        )
+      end
+
+      private
+
+      def apply_operations(conn)
+        operations.reduce(Success(conn)) do |new_conn, operation|
+          new_conn.bind { |c| apply_operation(c, operation) }
+        end
+      end
+
+      def apply_operation(conn, operation)
+        result = operation.(conn)
+        case result
+        when Conn::Clean
+          Success(result)
+        when Conn::Dirty
+          Failure(result)
+        else
+          raise InvalidOperationResult.new(result)
+        end
+      end
+
+      def extract_result(result)
+        extract_proc = :itself.to_proc
+
+        result.either(extract_proc, extract_proc)
+      end
+    end
+  end
+end

--- a/lib/web_pipe/dsl/class_context.rb
+++ b/lib/web_pipe/dsl/class_context.rb
@@ -51,8 +51,8 @@ module WebPipe
       def define_dsl
         DSL_METHODS.each do |method|
           module_exec(dsl_context) do |dsl_context|
-            define_method(method) do |*args|
-              dsl_context.method(method).(*args)
+            define_method(method) do |*args, &block|
+              dsl_context.method(method).(*args, &block)
             end
           end
         end

--- a/lib/web_pipe/dsl/dsl_context.rb
+++ b/lib/web_pipe/dsl/dsl_context.rb
@@ -41,12 +41,17 @@ module WebPipe
 
       # Creates and adds a plug to the stack.
       #
+      # The spec can be given as a {Plug::Spec} or as a block, which
+      # is captured into a {Proc} (one of the options for a
+      # {Plug::Spec}.
+      #
       # @param name [Plug::Name[]]
-      # @param with [Plug::Spec[]]
+      # @param spec [Plug::Spec[]]
+      # @param block_spec [Proc]
       #
       # @return [Array<Plug>]
-      def plug(name, with = nil)
-        plugs << Plug.new(name, with)
+      def plug(name, spec = nil, &block_spec)
+        plugs << Plug.new(name, spec || block_spec)
       end
     end
   end

--- a/lib/web_pipe/dsl/dsl_context.rb
+++ b/lib/web_pipe/dsl/dsl_context.rb
@@ -45,7 +45,7 @@ module WebPipe
       # @param with [Plug::Spec[]]
       #
       # @return [Array<Plug>]
-      def plug(name, with: nil)
+      def plug(name, with = nil)
         plugs << Plug.new(name, with)
       end
     end

--- a/lib/web_pipe/extensions/dry_view/dry_view.rb
+++ b/lib/web_pipe/extensions/dry_view/dry_view.rb
@@ -38,7 +38,7 @@ module WebPipe
   #
   #     Container = { 'views.say_hello' => SayHelloView.new }.freeze
   #
-  #     plug :container, with: WebPipe::Plugs::Container[Container]
+  #     plug :container, WebPipe::Plugs::Container[Container]
   #     plug :render
   #
   #     def render(conn)

--- a/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
+++ b/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
@@ -17,7 +17,7 @@ module WebPipe
     #
     #     ViewContext = (conn) -> { { current_path: conn.full_path } }
     #
-    #     plug :view_context, with: WebPipe::Plugs::ViewContext[ViewContext]
+    #     plug :view_context, WebPipe::Plugs::ViewContext[ViewContext]
     #     plug :render
     #
     #     def render

--- a/lib/web_pipe/plug.rb
+++ b/lib/web_pipe/plug.rb
@@ -1,6 +1,6 @@
 require 'dry/initializer'
 require 'web_pipe/types'
-require 'web_pipe/app'
+require 'web_pipe/conn_support/composition'
 
 module WebPipe
   # A plug is a specification to resolve a callable object.
@@ -35,9 +35,13 @@ module WebPipe
     # Type for the name of a plug.
     Name = Types::Strict::Symbol.constructor(&:to_sym)
 
-    # Type for the spec to resolve and {App::Operation} on a
-    # {Conn} used by {Plug}.
-    Spec = App::Operation | Types.Constant(nil) | Types::Strict::String | Types::Strict::Symbol
+    # Type for the spec to resolve and
+    # {ConnSupport::Composition::Operation} on a {Conn} used by
+    # {Plug}.
+    Spec = ConnSupport::Composition::Operation |
+           Types.Constant(nil) |
+           Types::Strict::String |
+           Types::Strict::Symbol
 
     # Type for an instance of self.
     Instance = Types.Instance(self)
@@ -68,7 +72,7 @@ module WebPipe
     # @param container [Types::Container[]]
     # @param object [Object]
     #
-    # @return [Operation[]]
+    # @return [ConnSupport::Composition::Operation[]]
     # @raise [InvalidPlugError] When nothing callable is resolved.
     def call(container, pipe)
       if spec.respond_to?(:call)
@@ -89,7 +93,7 @@ module WebPipe
     # @container container [Types::Container[]]
     # @object [Object]
     #
-    # @return [Array<Operation[]>]
+    # @return [Array<ConnSupport::Composition::Operation[]>]
     def self.inject_and_resolve(plugs, injections, container, object)
       plugs.map do |plug|
         if injections.has_key?(plug.name)

--- a/lib/web_pipe/plug.rb
+++ b/lib/web_pipe/plug.rb
@@ -25,8 +25,8 @@ module WebPipe
         super(
           <<~eos
             Plug with name +#{name}+ is invalid. It must be something
-            callable, an instance method when `with:` is not given, or
-            something callable registered in the container."
+            callable, an instance method when no operation is given,
+            or something callable registered in the container."
           eos
         )
       end

--- a/lib/web_pipe/plugs/container.rb
+++ b/lib/web_pipe/plugs/container.rb
@@ -13,7 +13,7 @@ module WebPipe
     #
     #     Cont = { name: SomeDependency.new }.freeze
     #
-    #     plug :container, with: WebPipe::Plugs::Container[Cont]
+    #     plug :container, WebPipe::Plugs::Container[Cont]
     #     plug :resolve
     #
     #     private

--- a/lib/web_pipe/plugs/content_type.rb
+++ b/lib/web_pipe/plugs/content_type.rb
@@ -10,7 +10,7 @@ module WebPipe
     #   class App
     #     include WebPipe
     #
-    #     plug :html, with: WebPipe::Plugs::ContentType['text/html']
+    #     plug :html, WebPipe::Plugs::ContentType['text/html']
     #   end
     module ContentType
       # Content-Type header

--- a/spec/integration/composition_spec.rb
+++ b/spec/integration/composition_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'support/env'
+
+RSpec.describe "Composition of WebPipe's" do
+  let(:pipe) do
+    Class.new do
+      include WebPipe
+
+      class One
+        include WebPipe
+
+        plug :one
+
+        private
+
+        def one(conn)
+          conn.set_response_body('One')
+        end
+      end
+
+      plug :one, &One.new
+      plug :two
+
+      private
+
+      def two(conn)
+        conn.set_response_body(
+          conn.response_body[0] + 'Two'
+        )
+      end
+    end.new
+  end
+
+  it 'plugging a WebPipe composes its plugs' do
+    expect(pipe.call(DEFAULT_ENV).last).to eq(['OneTwo'])
+  end
+end

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Resolving from a container" do
 
       include WebPipe.(container: Container)
 
-      plug :hello, with: 'plug.hello'
+      plug :hello, 'plug.hello'
     end.new
   end
 

--- a/spec/integration/injection_spec.rb
+++ b/spec/integration/injection_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Injection" do
     Class.new do
       include WebPipe
 
-      plug :hello, with: -> (conn) { conn.set_response_body('Hello, world!') }
+      plug :hello, -> (conn) { conn.set_response_body('Hello, world!') }
     end
   end
   let(:hello) { -> (conn) { conn.set_response_body('Hello, injected world!') } }

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Rack application" do
     Class.new do
       include WebPipe
 
-      plug :hello, with: -> (conn) do
+      plug :hello, -> (conn) do
         conn.
           set_response_body('Hello, world!').
           set_status(200)

--- a/spec/unit/web_pipe/app_spec.rb
+++ b/spec/unit/web_pipe/app_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'support/env'
+require 'web_pipe/conn_support/composition'
 require 'web_pipe/app'
 
 RSpec.describe WebPipe::App do
@@ -31,7 +32,9 @@ RSpec.describe WebPipe::App do
 
       expect {
         app.call(DEFAULT_ENV)
-      }.to raise_error(WebPipe::App::InvalidOperationResult)
+      }.to raise_error(
+             WebPipe::ConnSupport::Composition::InvalidOperationResult
+      )
     end
   end
 end

--- a/spec/unit/web_pipe/conn_support/composition_spec.rb
+++ b/spec/unit/web_pipe/conn_support/composition_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn_support/composition'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::ConnSupport::Composition do
+  let(:conn) { WebPipe::ConnSupport::Builder.call(DEFAULT_ENV) }
+  
+  describe '#call' do
+    it 'chains operations on Conn' do
+      op_1 = ->(conn) { conn.set_status(200) }
+      op_2 = ->(conn) { conn.set_response_body('foo') }
+
+      app = described_class.new([op_1, op_2])
+
+      expect(app.call(conn)).to eq(
+        op_2.(op_1.(conn))
+      )
+    end
+
+    it 'stops chain propagation once a conn is tainted' do
+      op_1 = ->(conn) { conn.set_status(200) }
+      op_2 = ->(conn) { conn.set_response_body('foo') }
+      op_3 = ->(conn) { conn.taint }
+      op_4 = ->(conn) { conn.set_response_body('bar') }
+
+      app = described_class.new([op_1, op_2, op_3, op_4])
+
+      expect(app.call(conn)).to eq(
+        op_3.(op_2.(op_1.(conn)))
+      )
+    end
+
+    it 'raises InvalidOperationReturn when one operation does not return a Conn' do
+      op = ->(_conn) { :foo }
+
+      app = described_class.new([op])
+
+      expect {
+        app.call(conn)
+      }.to raise_error(WebPipe::ConnSupport::Composition::InvalidOperationResult)
+    end
+  end
+end


### PR DESCRIPTION
Allow composition of WebPipe's

WebPipe representation as a proc is the composition of all its plug operations. Thus, it is itself an operation taking a `Conn` and returning a `Conn`. It can be leveraged to be plugged as any other
operation and compose WebPipe's:

```ruby
class HtmlApp
  include WebPipe

  plug :html

  private

  def html(conn)
    conn.set_response_header('Content-Type', 'text/html')
  end
end

class App
  include WebPipe

  plug :html, &HtmlApp.new
  plug :body

  private

  def body(conn)
     conn.set_response_body('Hello, world!')
  end
end
```

This PR introduces a breaking change. `with:` is no longer used to specify the operation when plugging. Now it is just the second positional argument:

```ruby
plug :name, 'operation'
```