### PR TITLE
Add composition of middlewares from a pipe class

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,19 @@ class App
 end
 ```
 
+It is also possible to compose all the middlewares from another pipe
+class. Extending from previous example:
+
+```ruby
+class App2
+  include WebPipe
+
+  use App # it will also use Middleware1 and Middleware2
+
+  plug :hello, ->(conn) { conn }
+end
+```
+
 ### Standalone usage
 
 If you prefer, you can use the application builder without the

--- a/lib/web_pipe/dsl/dsl_context.rb
+++ b/lib/web_pipe/dsl/dsl_context.rb
@@ -2,6 +2,7 @@ require 'dry/initializer'
 require 'web_pipe/types'
 require 'web_pipe/plug'
 require 'web_pipe/rack/middleware'
+require 'web_pipe/rack/middleware_specification'
 
 module WebPipe
   module DSL
@@ -21,22 +22,27 @@ module WebPipe
 
       include Dry::Initializer.define -> do
         param :middlewares,
-              type: Types.Array(Rack::Middleware::Instance)
+              type: Types.Array(Rack::Middleware)
 
         param :plugs,
               type: Types.Array(Plug::Instance)
       end
 
-      # Creates and add a rack middleware to the stack.
+      # Creates and add rack middlewares to the stack.
       #
-      # @param middleware
-      # [WebPipe::Rack::Middleware::MiddlewareClass[]] Rack middleware
-      # @param middleware [WebPipe::Rack::Options[]] Options to
-      # initialize
+      # The spec can be given in two forms:
+      #
+      # - As one or two arguments, first one being a
+      # {::Rack::Middleware} class and second one optionally its
+      # initialization options.
+      # - As a {WebPipe} class, in which case all its rack middlewares
+      # will be added to the stack in order.
+      #
+      # @param spec [Rack::MiddlewareSpecification::Spec[]]
       #
       # @return [Array<Rack::Middleware>]
-      def use(middleware, *options)
-        middlewares << Rack::Middleware.new(middleware, options)
+      def use(*spec)
+        middlewares.push(*Rack::MiddlewareSpecification.call(spec))
       end
 
       # Creates and adds a plug to the stack.

--- a/lib/web_pipe/rack/app_with_middlewares.rb
+++ b/lib/web_pipe/rack/app_with_middlewares.rb
@@ -24,7 +24,7 @@ module WebPipe
 
       include Dry::Initializer.define -> do
         param :rack_middlewares,
-              type: Types.Array(Middleware::Instance)
+              type: Types.Array(Middleware)
 
         param :app, type: App
       end
@@ -51,7 +51,7 @@ module WebPipe
       def build_rack_app(rack_middlewares, app)
         ::Rack::Builder.new.tap do |b|
           rack_middlewares.each do |middleware|
-            b.use(middleware.middleware, *middleware.middleware_options)
+            b.use(middleware.middleware, *middleware.options)
           end
           b.run(app)
         end

--- a/lib/web_pipe/rack/middleware.rb
+++ b/lib/web_pipe/rack/middleware.rb
@@ -1,14 +1,14 @@
 require 'dry/initializer'
 require 'web_pipe/types'
+require 'dry/struct'
 
 module WebPipe
   module Rack
     # Simple data structure to represent a rack middleware class with
     # its initialization options.
-    class Middleware
-      # Type for an instance of self.
-      Instance = Types.Instance(self)
-
+    #
+    # @api private
+    class Middleware < Dry::Struct
       # Type for a rack middleware class.
       MiddlewareClass = Types.Instance(Class)
 
@@ -17,17 +17,11 @@ module WebPipe
 
       # @!attribute [r] middleware
       #   @return [MiddlewareClass[]] Rack middleware
+      attribute :middleware, MiddlewareClass
 
       # @!attribute [r] options
-      # @return [Options[]]
-      # Options to initialize the rack middleware
-
-
-      include Dry::Initializer.define -> do
-        param :middleware, type: MiddlewareClass
-
-        param :middleware_options, type: Options
-      end
+      # @return [Options[]] Options to initialize the rack middleware
+      attribute :options, Options
     end
   end
 end

--- a/lib/web_pipe/rack/middleware_specification.rb
+++ b/lib/web_pipe/rack/middleware_specification.rb
@@ -1,0 +1,33 @@
+require 'web_pipe/rack/middleware'
+require 'web_pipe/types'
+
+module WebPipe
+  module Rack
+    # Specification on how to resolve {Rack::Middleware}'s.
+    #
+    # Rack middlewares can be specified in two ways:
+    #
+    # - As an array where fist element is a rack middleware class
+    # while the rest of elements are its initialization options.
+    # - A single element array where it is a class including
+    # {WebPipe}. This specifies all {Rack::Middlewares} configured
+    # for that {WebPipe}.
+    #
+    # @api private
+    module MiddlewareSpecification
+      # Resolves {Rack::Middlewares} from given specification.
+      #
+      # @param spec [Array]
+      # @return [Array<Rack::Middleware>]
+      def self.call(spec)
+        klass = spec[0]
+        options = spec[1..-1] || Types::EMPTY_ARRAY
+        if klass.included_modules.include?(WebPipe)
+          klass.middlewares
+        elsif klass.is_a?(Class)
+          [Middleware.new(middleware: klass, options: options)]
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/middlewares_composition_spec.rb
+++ b/spec/integration/middlewares_composition_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'support/env'
+
+RSpec.describe "Middlewares composition" do
+  before do
+    class FirstNameMiddleware
+      attr_reader :app
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env['first_name_middleware.name'] = 'Joe'
+        app.call(env)
+      end
+    end
+
+    class LastNameMiddleware
+      attr_reader :app
+      attr_reader :name
+
+      def initialize(app, name:)
+        @app = app
+        @name = name
+      end
+
+      def call(env)
+        env['last_name_middleware.name'] = name
+        app.call(env)
+      end
+    end
+
+    class AppWithMiddlewares
+      include WebPipe
+
+      use FirstNameMiddleware
+      use LastNameMiddleware, name: 'Doe'
+    end
+  end
+
+  let(:pipe) do
+    Class.new do
+      include WebPipe
+
+      use AppWithMiddlewares
+
+      plug :hello
+
+      private
+
+      def hello(conn)
+        first_name = conn.env['first_name_middleware.name']
+        last_name = conn.env['last_name_middleware.name']
+        conn.
+          set_response_body(
+            "Hello #{first_name} #{last_name}"
+          ).
+          set_status(200)
+      end
+    end.new
+  end
+
+  it 'using a WebPipe composes its middlewares' do
+    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Hello Joe Doe')
+  end
+end

--- a/spec/integration/plugs_composition_spec.rb
+++ b/spec/integration/plugs_composition_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/env'
 
-RSpec.describe "Composition of WebPipe's" do
+RSpec.describe "Plugs composition" do
   let(:pipe) do
     Class.new do
       include WebPipe
@@ -31,7 +31,7 @@ RSpec.describe "Composition of WebPipe's" do
     end.new
   end
 
-  it 'plugging a WebPipe composes its plugs' do
+  it 'plugging a WebPipe composes its plug operations' do
     expect(pipe.call(DEFAULT_ENV).last).to eq(['OneTwo'])
   end
 end

--- a/spec/unit/web_pipe/rack/middleware_specification_spec.rb
+++ b/spec/unit/web_pipe/rack/middleware_specification_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'web_pipe'
+require 'web_pipe/rack/middleware'
+require 'web_pipe/rack/middleware_specification'
+
+RSpec.describe WebPipe::Rack::MiddlewareSpecification do
+  describe '.call' do
+    Middleware = Class.new do
+      def initialize(app, options = nil)
+        @app = app
+        @options = options
+      end
+
+      def call(env)
+        env['middleware.options'] = @options
+        @app = app.(env)
+      end
+    end
+
+    context 'when spec is a WebPipe class' do
+      it "returns an array with its WebPipe::Rack::Middleware's" do
+        Pipe = Class.new do
+          include WebPipe
+
+          use Middleware
+        end
+
+        expect(described_class.([Pipe])).to be(Pipe.middlewares)
+      end
+    end
+
+    context 'when spec is a class' do
+      it "returns it as a WebPipe::Rack::Middleware with empty options" do
+        expect(described_class.([Middleware])).to eq(
+          [WebPipe::Rack::Middleware.new(middleware: Middleware, options: [])]
+        )
+      end
+    end
+
+    context 'when spec is a class with options' do
+      it "returns it as a WebPipe::Rack::Middleware with given options" do
+        expect(described_class.([Middleware, :a])).to eq(
+          [WebPipe::Rack::Middleware.new(middleware: Middleware, options: [:a])]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes it possible:

```ruby
class App
  include WebPipe

  use Middleware1
  use Middleware2
end

class App2
  include WebPipe

  use App
end
```