### PR TITLE
Compose plugs from the WebPipe instance

### DIFF
--- a/spec/integration/plug_composition_spec.rb
+++ b/spec/integration/plug_composition_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Plug composition" do
     Class.new do
       include WebPipe
 
-      plug :one, &One.new
+      plug :one, One.new
       plug :two
 
       private


### PR DESCRIPTION
It avoids the need to manually call `#to_proc` in it. So, right now,
both of the following are valid:

```ruby
plug :app, &App.new
plug :app, App.new
```