### PR TITLE
Fix middlewares unable to modify a default response

### DIFF
--- a/lib/web_pipe/conn_support/types.rb
+++ b/lib/web_pipe/conn_support/types.rb
@@ -34,15 +34,15 @@ module WebPipe
       Status = Strict::Integer.
                  default(200).
                  constrained(gteq: 100, lteq: 599)
-      ResponseBody = Interface(:each).default([''].freeze)
+      ResponseBody = Interface(:each).default { [''] }
 
       Headers = Strict::Hash.
                   map(Strict::String, Strict::String).
-                  default({}.freeze)
+                  default { {} }
 
       Bag = Strict::Hash.
               map(Strict::Symbol, Strict::Any).
-              default({}.freeze)
+              default { {} }
     end
   end
 end


### PR DESCRIPTION
When response headers or body were not set, the default was a frozen
instance. Consequently, middlewares were unable to modify it using
conventional destructive methods. For example, `rack-session` was unable
to add `SET-COOKIE` header because it uses `Hash#[]`.