### PR TITLE
Add extension adding flash bag functionality

### DIFF
--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -19,4 +19,8 @@ module WebPipe
   register_extension :dry_view do
     require 'web_pipe/extensions/dry_view/dry_view'
   end
+
+  register_extension :flash do
+    require 'web_pipe/extensions/flash/flash'
+  end
 end

--- a/lib/web_pipe/conn_support/errors.rb
+++ b/lib/web_pipe/conn_support/errors.rb
@@ -12,5 +12,21 @@ module WebPipe
         )
       end
     end
+
+    # Error raised when trying to use a conn's feature which requires
+    # a rack middleware which is not present
+    class MissingMiddlewareError < RuntimeError
+      # @param feature [String] Name of the feature intended to be used
+      # @param middleware [String] Name of the missing middleware
+      # @param gem [String] Gem name for the middleware
+      def initialize(feature, middleware, gem)
+        super(
+          <<~eos
+            In order to use #{feature} you must use #{middleware} middleware:
+            https://rubygems.org/gems/#{gem}
+          eos
+        )
+      end
+    end
   end
 end

--- a/lib/web_pipe/conn_support/types.rb
+++ b/lib/web_pipe/conn_support/types.rb
@@ -34,15 +34,15 @@ module WebPipe
       Status = Strict::Integer.
                  default(200).
                  constrained(gteq: 100, lteq: 599)
-      ResponseBody = Interface(:each).default([''].freeze)
+      ResponseBody = Interface(:each).default { [''] }
 
       Headers = Strict::Hash.
                   map(Strict::String, Strict::String).
-                  default({}.freeze)
+                  default { {} }
 
       Bag = Strict::Hash.
               map(Strict::Symbol, Strict::Any).
-              default({}.freeze)
+              default { {} }
     end
   end
 end

--- a/lib/web_pipe/extensions/flash/flash.rb
+++ b/lib/web_pipe/extensions/flash/flash.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'web_pipe/conn'
+require 'web_pipe/conn_support/errors'
+
+module WebPipe
+  # Provides with a tipical flash messages functionality.
+  #
+  # @example
+  #   require 'web_pipe'
+  #   require 'rack/session/cookie'
+  #   require 'rack-flash'
+  #
+  #   WebPipe.load_extensions(:flash)
+  #   
+  #   class MyApp
+  #     include WebPipe
+  #
+  #     use :session, Rack::Session::Cookie, secret: 'secret'
+  #     use :flash, Rack::Flash
+  #
+  #     plug :put_in_flash, ->(conn) { conn.put_flash(:notice, 'Hello world') }
+  #     plug :put_in_flash_now, ->(conn) { conn.put_flash_now(:notice_now, 'Hello world now') }
+  #   end
+  #
+  # Usually, you will end up making `conn.flash` available to your view system:
+  #
+  # @example
+  #   <div class="notice"><%= flash[:notice] %></div>
+  #
+  # For this extension to be used, `Rack::Flash` middleware must be
+  # added to the stack (gem name is `rack-flash3`. This middleware in
+  # turns depend on `Rack::Session` middleware.
+  #
+  # This extension is a very simple wrapper around `Rack::Flash` API.
+  #
+  # @see https://github.com/nakajima/rack-flash
+  class Conn < Dry::Struct
+    RACK_FLASH_KEY = 'x-rack.flash'
+    
+    # Returns the flash bag.
+    #
+    # @return [Rack::Flash::FlashHash]
+    #
+    # @raises ConnSupport::MissingMiddlewareError when `Rack::Flash`
+    # is not being used as middleware
+    def flash
+      env.fetch(RACK_FLASH_KEY) do
+        raise ConnSupport::MissingMiddlewareError.new(
+                'flash', 'Rack::Flash', 'rack-flash3'
+              )
+      end
+    end
+
+    # Puts an item to the flash bag to be consumed by next request.
+    #
+    # @param key [String]
+    # @param value [String]
+    def put_flash(key, value)
+      flash[key] = value
+      self
+    end
+
+    # Puts an item to the flash bag to be consumed by the same request
+    # in process.
+    #
+    # @param key [String]
+    # @param value [String]
+    def put_flash_now(key, value)
+      flash.now[key] = value
+      self
+    end
+  end
+end

--- a/spec/extensions/flash/flash_spec.rb
+++ b/spec/extensions/flash/flash_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn'
+require 'web_pipe/conn_support/builder'
+require 'web_pipe/conn_support/errors'
+require 'rack-flash'
+
+RSpec.describe WebPipe::Conn do
+  before do
+    WebPipe.load_extensions(:flash)
+  end
+
+  let(:flash) { Rack::Flash::FlashHash.new({}) }
+
+  describe '#flash' do
+    context "when rack-flash key is found in env" do
+      it 'returns its value' do
+        env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+        conn = WebPipe::ConnSupport::Builder.call(env)
+
+        expect(conn.flash).to be(flash)
+      end
+    end
+
+    context "when rack-flash key is not found in env" do
+      it 'raises a MissingMiddlewareError' do
+        conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+
+        expect { conn.flash }.to raise_error(WebPipe::ConnSupport::MissingMiddlewareError)
+      end
+    end
+  end
+
+  describe '#put_flash' do
+    it 'sets given key to given value in flash' do
+      env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      conn = conn.put_flash(:error, 'error')
+
+      expect(flash[:error]).to eq('error')
+    end
+  end
+
+  describe '#put_flash_now' do
+    it 'sets given key to given value in flash cache' do
+      env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      conn = conn.put_flash_now(:error, 'error')
+
+      expect(flash.send(:cache)[:error]).to eq('error')
+    end
+  end
+end

--- a/spec/extensions/flash/integration/flash_spec.rb
+++ b/spec/extensions/flash/integration/flash_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe'
+require 'rack/session/cookie'
+require 'rack-flash'
+
+RSpec.describe 'Using flash' do
+  before { WebPipe.load_extensions(:flash) }
+  
+  let(:pipe) do
+    Class.new do
+      include WebPipe
+
+      use :session, ::Rack::Session::Cookie, secret: 'secret'
+      use :flash, ::Rack::Flash
+
+      plug :put_in_flash
+      plug :build_response
+
+      private
+
+      def put_in_flash(conn)
+        conn.
+          put_flash(:error, 'Error').
+          put_flash_now(:now, 'now')
+      end
+
+      def build_response(conn)
+        conn.set_response_body(
+          "#{conn.flash[:error]} #{conn.flash[:now]}"
+        )
+      end
+    end.new
+  end
+
+  it 'can put and read from flash' do
+    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Error now')
+  end
+end

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redcarpet", "~> 3.4"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "dry-view", "~> 0.7"
+  spec.add_development_dependency "rack-flash3", "~> 1.0"
 end


### PR DESCRIPTION
Add extension adding flash bag functionality

```ruby
require 'web_pipe'
require 'rack/session/cookie'
require 'rack-flash'

WebPipe.load_extensions(:flash)

class MyApp
  include WebPipe

  use :session, Rack::Session::Cookie, secret: 'secret'
  use :flash, Rack::Flash

  plug :put_in_flash, ->(conn) { conn.put_flash(:notice, 'Hello world') }
  plug :put_in_flash_now, ->(conn) { conn.put_flash_now(:notice_now, 'Hello world now') }
end
```

For this extension to be used, `Rack::Flash` middleware must be added to
the stack (gem name is `rack-flash3`. This middleware in turns depend on
`Rack::Session` middleware.