### PR TITLE
Dry-schema integration

### DIFF
--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -16,6 +16,12 @@ module WebPipe
     DSL::Builder.new(*args)
   end
 
+  register_extension :dry_schema do
+    require 'web_pipe/extensions/dry_schema/dry_schema'
+    require 'web_pipe/extensions/dry_schema/plugs/sanitize_params'
+    require 'web_pipe/extensions/dry_schema/plugs/param_sanitization_handler'
+  end
+  
   register_extension :dry_view do
     require 'web_pipe/extensions/dry_view/dry_view'
     require 'web_pipe/extensions/dry_view/plugs/view_context'

--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -1,0 +1,78 @@
+require 'web_pipe'
+
+module WebPipe
+  # Integration with `dry-schema` validation library.
+  #
+  # This extension provides a simple integration with `dry-schema`
+  # library to streamline param sanitization.
+  #
+  # On its own, the library just provides with a
+  # `Conn#sanitized_params` method, which will return what is set into
+  # bag's `:sanitized_params` key.
+  #
+  # This key in the bag is what will be populated by `SanitizeParams`
+  # plug, which accepts a `dry-validation` schema that will be applied
+  # to `Conn#params`:
+  #
+  # @example
+  #  require 'web_pipe'
+  #
+  #  WebPipe.load_extensions(:dry_schema)
+  #
+  #  class App
+  #    include WebPipe
+  #
+  #    Schema = Dry::Schema.Params do
+  #      required(:name).filled(:string)
+  #    end
+  #
+  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
+  #    plug(:do_something_with_params) do |conn|
+  #      DB.persist(:entity, conn.sanitized_params)
+  #    end
+  #  end
+  #
+  # By default, when the result of applying the schema is a failure,
+  # {Conn} is tainted with a 500 as status code. However, you can
+  # specify your own handler for the unhappy path. It will take the
+  # {Conn} and {Dry::Schema::Result} instances as arguments:
+  #
+  # @example
+  #   plug :sanitize_params, WebPipe::Plugs::SanitizeParams[
+  #                            Schema,
+  #                            ->(conn, result) { ... }
+  #                          ]
+  #
+  # A common workflow is applying the same handler for all param
+  # sanitization across your application. This can be achieved setting
+  # a `:param_sanitization_handler` bag key in a upstream operation
+  # which can be composed downstream for any number of
+  # pipes. `SanitizeParams` will used configured handler if none is
+  # injected as argument. Another plug `ParamSanitizationHandler`
+  # exists to help with this process:
+  #
+  # @example
+  #  class App
+  #    plug :sanitization_handler, WebPipe::Plugs::ParamSanitizationHandler[
+  #                                  ->(conn, result) { ... }
+  #                                ]
+  #  end
+  #
+  #  class Subapp
+  #    Schema = Dry::Schema.Params { ... }
+  #
+  #    plug :app, App.new
+  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
+  #  end
+  #
+  # @see https://dry-rb.org/gems/dry-schema/
+  module DrySchema
+    SANITIZED_PARAMS_KEY = :sanitized_params
+
+    def sanitized_params
+      fetch(SANITIZED_PARAMS_KEY)
+    end
+  end
+
+  Conn.include(DrySchema)
+end

--- a/lib/web_pipe/extensions/dry_schema/plugs/param_sanitization_handler.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/param_sanitization_handler.rb
@@ -1,0 +1,27 @@
+require 'web_pipe/types'
+
+module WebPipe
+  module Plugs
+    # Sets `:param_sanitization_handler` bag key.
+    #
+    # @see WebPipe::DrySchema
+    module ParamSanitizationHandler
+      # Bag key to store the handler.
+      #
+      # @return [Symbol]
+      PARAM_SANITIZATION_HANDLER_KEY = :param_sanitization_handler
+
+      # Type constructor for the handler.
+      Handler = Types.Interface(:call)
+
+      # @param handler [Handler[]]
+      #
+      # @return [ConnSupport::Composition::Operation[]]
+      def self.[](handler)
+        lambda do |conn|
+          conn.put(PARAM_SANITIZATION_HANDLER_KEY, Handler[handler])
+        end
+      end
+    end
+  end
+end

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -1,0 +1,46 @@
+require 'web_pipe/types'
+require 'web_pipe/extensions/dry_schema/dry_schema'
+require 'web_pipe/extensions/dry_schema/plugs/param_sanitization_handler'
+
+module WebPipe
+  module Plugs
+    # Sanitize {Conn#params} with given `dry-schema` Schema.
+    #
+    # @see WebPipe::DrySchema
+    module SanitizeParams
+      # Default handler if none is configured nor injected.
+      #
+      # @return [ParamSanitizationHandler::Handler[]]
+      DEFAULT_HANDLER = lambda do |conn, _result|
+        conn.
+          set_status(500).
+          set_response_body('Given params do not conform with the expected schema').
+          taint
+      end
+
+      # @param schema [Dry::Schema::Processor]
+      # @param handler [ParamSanitizationHandler::Handler[]]
+      #
+      # @return [ConnSupport::Composition::Operation[], Types::Undefined]
+      def self.[](schema, handler = Types::Undefined)
+        lambda do |conn|
+          result = schema.(conn.params)
+          if result.success?
+            conn.put(DrySchema::SANITIZED_PARAMS_KEY, result.output)
+          else
+            get_handler(conn, handler).(conn, result)
+          end
+        end
+      end
+
+      def self.get_handler(conn, handler)
+        return handler unless handler == Types::Undefined
+
+        conn.fetch(
+          Plugs::ParamSanitizationHandler::PARAM_SANITIZATION_HANDLER_KEY, DEFAULT_HANDLER
+        )
+      end
+      private_class_method :get_handler
+    end
+  end
+end

--- a/spec/extensions/dry_schema/dry_schema_spec.rb
+++ b/spec/extensions/dry_schema/dry_schema_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::Conn do
+  before { WebPipe.load_extensions(:dry_schema) }
+
+  describe '#sanitized_params' do
+    it "returns bag's sanitized key" do
+      conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+      sanitized_params = {}.freeze
+
+      new_conn = conn.put(:sanitized_params, sanitized_params)
+
+      expect(new_conn.sanitized_params).to be(sanitized_params)
+    end
+  end
+end

--- a/spec/extensions/dry_schema/plugs/param_sanitization_handler_spec.rb
+++ b/spec/extensions/dry_schema/plugs/param_sanitization_handler_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn_support/builder'
+require 'web_pipe/extensions/dry_schema/plugs/param_sanitization_handler'
+
+RSpec.describe WebPipe::Plugs::ParamSanitizationHandler do
+  describe '.[]' do
+    it 'operation sets :param_sanitization_handler bag key' do
+      conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+      handler = ->(conn, _result) { conn }
+      operation = described_class[handler]
+
+      new_conn = operation.(conn)
+
+      expect(new_conn.fetch(:param_sanitization_handler)).to be(handler)
+    end
+  end
+end

--- a/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
+++ b/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'support/env'
+require 'dry/schema'
+require 'web_pipe/extensions/dry_schema/plugs/sanitize_params'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::Plugs::SanitizeParams do
+  describe '.[]' do
+    let(:schema) do
+      schema = Dry::Schema.Params do
+        required(:name)
+      end
+    end
+
+    context 'operation on success' do
+      it "sets sanitized_params bag's key" do
+        env = DEFAULT_ENV.merge(Rack::QUERY_STRING => 'name=Joe')
+        conn = WebPipe::ConnSupport::Builder.(env)
+        operation = described_class[schema]
+
+        new_conn = operation.(conn)
+
+        expect(new_conn.sanitized_params).to eq(name: 'Joe')
+      end
+    end
+
+    context 'operation on failure' do
+      it 'uses given handler if it is injected' do
+        configured_handler = lambda do |conn, _result|
+          conn.
+            set_response_body('Something went wrong').
+            set_status(500).
+            taint
+        end
+        injected_handler = lambda do |conn, result|
+          conn.
+            set_response_body(result.errors.messages.inspect).
+            set_status(500).
+            taint
+        end
+        conn = WebPipe::ConnSupport::Builder.
+                 (DEFAULT_ENV).
+                 put(:param_sanitization_handler, configured_handler)
+        operation = described_class[schema, injected_handler]
+
+        new_conn = operation.(conn)
+
+        expect(new_conn.response_body[0]).to include('is missing')
+      end
+
+      it 'uses configured handler if none is injected' do
+        configured_handler = lambda do |conn, _result|
+          conn.
+            set_response_body('Something went wrong').
+            set_status(500).
+            taint
+        end
+        conn = WebPipe::ConnSupport::Builder.
+                 (DEFAULT_ENV).
+                 put(:param_sanitization_handler, configured_handler)
+        operation = described_class[schema]
+
+        new_conn = operation.(conn)
+
+        expect(new_conn.response_body[0]).to eq('Something went wrong')
+      end
+
+      it 'uses default handler if none is injected nor configured' do
+        conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+        operation = described_class[schema]
+
+        new_conn = operation.(conn)
+
+        expect(new_conn.status).to be(500)
+      end
+    end
+  end
+end

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -49,4 +49,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "dry-view", "~> 0.7"
   spec.add_development_dependency "rack-flash3", "~> 1.0"
+  spec.add_development_dependency "dry-schema", "~> 1.0"
 end


### PR DESCRIPTION
Integration with `dry-schema` validation library.

This extension provides a simple integration with `dry-schema`
library to streamline param sanitization.

On its own, the library just provides with a
`Conn#sanitized_params` method, which will return what is set into
bag's `:sanitized_params` key.

This key in the bag is what will be populated by `SanitizeParams`
plug, which accepts a `dry-validation` schema that will be applied
to `Conn#params`:

```ruby
require 'web_pipe'

WebPipe.load_extensions(:dry_schema)

class App
  include WebPipe

  Schema = Dry::Schema.Params do
    required(:name).filled(:string)
  end

  plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
  plug(:do_something_with_params) do |conn|
    DB.persist(:entity, conn.sanitized_params)
  end
end
```

By default, when the result of applying the schema is a failure,
`Conn` is tainted with a 500 as status code. However, you can
specify your own handler for the unhappy path. It will take the
`Conn` and `Dry::Schema::Result` instances as arguments:

```ruby
plug :sanitize_params, WebPipe::Plugs::SanitizeParams[
                           Schema,
                           ->(conn, result) { ... }
                         ]
```

A common workflow is applying the same handler for all param
sanitization across your application. This can be achieved setting
a `:param_sanitization_handler` bag key in a upstream operation
which can be composed downstream for any number of
pipes. `SanitizeParams` will used configured handler if none is
injected as argument. Another plug `ParamSanitizationHandler`
exists to help with this process:

```ruby
class App
  plug :sanitization_handler, WebPipe::Plugs::ParamSanitizationHandler[
                                ->(conn, result) { ... }
                              ]
end

class Subapp
  Schema = Dry::Schema.Params { ... }

  plug :app, App.new
  plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
end
```