### PR TITLE
Add extension to easily create redirects

### DIFF
--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -35,4 +35,8 @@ module WebPipe
   register_extension :flash do
     require 'web_pipe/extensions/flash/flash'
   end
+
+  register_extension :redirect do
+    require 'web_pipe/extensions/redirect/redirect'
+  end
 end

--- a/lib/web_pipe/extensions/redirect/redirect.rb
+++ b/lib/web_pipe/extensions/redirect/redirect.rb
@@ -1,0 +1,39 @@
+require 'web_pipe/types'
+
+module WebPipe
+  # Helper method to create redirect responses.
+  #
+  # This extensions adds a {#redirect} method to {Conn} which helps
+  # setting the `Location` header and the status code needed to
+  # instruct the browser to perform a redirect. By default, `302`
+  # status code is used.
+  #
+  # @example
+  #  require 'web_pipe'
+  #
+  #  WebPipe.load_extensions(:redirect)
+  #
+  #  class MyApp
+  #    include WebPipe
+  #
+  #    plug(:redirect) do |conn|
+  #      conn.redirect('/', 301)
+  #    end
+  #  end
+  module Redirect
+    # Location header
+    LOCATION_HEADER = 'Location'
+
+    # Valid type for a redirect status code
+    RedirectCode = Types::Strict::Integer.constrained(gteq: 300, lteq: 399)
+    
+    # @param path [String]
+    # @param code [Integer]
+    def redirect(path, code = 302)
+      add_response_header(LOCATION_HEADER, path).
+        set_status(RedirectCode[code])
+    end
+  end
+
+  Conn.include(Redirect)
+end

--- a/spec/extensions/redirect/redirect_spec.rb
+++ b/spec/extensions/redirect/redirect_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::Conn do
+  before { WebPipe.load_extensions(:redirect) }
+
+  describe '#redirect' do
+    let(:conn) { WebPipe::ConnSupport::Builder.(DEFAULT_ENV) }
+    let(:new_conn) { conn.redirect('/here') }
+
+    it 'uses 302 as default status code' do
+      expect(new_conn.status).to be(302)
+    end
+
+    it 'sets given path as Location header' do
+      expect(new_conn.response_headers['Location']).to eq('/here')
+    end
+  end
+end


### PR DESCRIPTION
If none is given, default status code is 302.

```ruby
require 'web_pipe'

WebPipe.load_extensions(:redirect)

class MyApp
  include WebPipe

  plug(:redirect) do |conn|
    conn.redirect('/') # same as conn.redirect('/', 302)
  end
end
```