### PR TITLE
Extension integrating with rack session

### DIFF
--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -43,4 +43,8 @@ module WebPipe
   register_extension :redirect do
     require 'web_pipe/extensions/redirect/redirect'
   end
+
+  register_extension :session do
+    require 'web_pipe/extensions/session/session'
+  end
 end

--- a/lib/web_pipe/extensions/flash/flash.rb
+++ b/lib/web_pipe/extensions/flash/flash.rb
@@ -47,7 +47,7 @@ module WebPipe
     def flash
       env.fetch(RACK_FLASH_KEY) do
         raise ConnSupport::MissingMiddlewareError.new(
-                'flash', 'Rack::Flash', 'rack-flash3'
+                'flash', 'Rack::Flash', 'https://rubygems.org/gems/rack-flash3'
               )
       end
     end

--- a/lib/web_pipe/extensions/session/session.rb
+++ b/lib/web_pipe/extensions/session/session.rb
@@ -1,0 +1,86 @@
+require 'web_pipe/conn'
+require 'web_pipe/types'
+require 'rack'
+
+module WebPipe
+  # Wrapper around Rack::Session middlewares.
+  #
+  # This extension provides with helper methods to retrieve rack
+  # session and work with it while still being able to chain {Conn}
+  # method calls.
+  #
+  # It requires one of `Rack::Session` middlewares to be present.
+  #
+  # @example
+  #   require 'web_pipe'
+  #
+  #   WebPipe.load_extensions(:session)
+  #
+  #   class MyApp
+  #     include WebPipe
+  #
+  #     use Rack::Cookie, secret: 'top_secret'
+  #
+  #     plug :put_session, ->(conn) { conn.put_session('foo', 'bar') }
+  #     plug :fetch_session, ->(conn) { conn.put(:foo, conn.fetch_session('foo')) }
+  #     plug :delete_session, ->(conn) { conn.delete_session('foo') }
+  #     plug :clear_session, ->(conn) { conn.clear_session }
+  #   end
+  module Session
+    # Type for session keys.
+    SESSION_KEY = Types::Strict::String
+
+    # Returns Rack::Session's hash
+    #
+    # @return [Rack::Session::Abstract::SessionHash]
+    def session
+      env.fetch(::Rack::RACK_SESSION) do
+        raise ConnSupport::MissingMiddlewareError.new(
+                'session', 'Rack::Session', 'https://www.rubydoc.info/github/rack/rack/Rack/Session'
+              )
+      end
+    end
+
+    # Fetches given key from the session.
+    #
+    # @param key [SESSION_KEY[]] Session key to fetch
+    # @param default [Any] Default value if key is not found
+    # @yieldreturn Default value if key is not found and default is not given
+    # @raise KeyError When key is not found and not default nor block are given
+    # @return [Any]
+    def fetch_session(*args, &block)
+      SESSION_KEY[args[0]]
+      session.fetch(*args, &block)
+    end
+
+
+    # Puts given key/value pair to the session.
+    #
+    # @param key [SESSION_KEY[]] Session key
+    # @param value [Any] Value
+    # @return [Conn]
+    def put_session(key, value)
+      session[SESSION_KEY[key]] = value
+      self
+    end
+
+    # Deletes given key form the session.
+    #
+    # @param key [SESSION_KEY[]] Session key
+    # @return [Conn]
+    def delete_session(key)
+      session.delete(SESSION_KEY[key])
+      self
+    end
+
+    # Deletes everything from the session.
+    #
+    # @return [Conn]
+    def clear_session
+      session.clear
+      self
+    end
+  end
+
+  Conn.include(Session)
+end

--- a/spec/extensions/container/container_spec.rb
+++ b/spec/extensions/container/container_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#container' do
     it "returns bag's container key" do
-      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.call(default_env)
       container = {}.freeze
 
       new_conn = conn.put(:container, container)

--- a/spec/extensions/container/plugs/container_spec.rb
+++ b/spec/extensions/container/plugs/container_spec.rb
@@ -6,7 +6,7 @@ require 'web_pipe/conn_support/builder'
 RSpec.describe WebPipe::Plugs::Container do
   describe '.[]' do
     it "creates an operation which sets argument into bag's ':container' key" do
-      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.call(default_env)
       container = {}.freeze
       plug = described_class[container]
 

--- a/spec/extensions/cookies/cookies_spec.rb
+++ b/spec/extensions/cookies/cookies_spec.rb
@@ -5,7 +5,7 @@ require 'web_pipe/conn_support/builder'
 RSpec.describe WebPipe::Conn do
   before { WebPipe.load_extensions(:cookies) }
 
-  let(:conn) { WebPipe::ConnSupport::Builder.(DEFAULT_ENV) }
+  let(:conn) { WebPipe::ConnSupport::Builder.(default_env) }
 
   describe '#set_cookie' do
     it 'sets given name/value pair to the Set-Cookie header' do

--- a/spec/extensions/dry_schema/dry_schema_spec.rb
+++ b/spec/extensions/dry_schema/dry_schema_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#sanitized_params' do
     it "returns bag's sanitized key" do
-      conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.(default_env)
       sanitized_params = {}.freeze
 
       new_conn = conn.put(:sanitized_params, sanitized_params)

--- a/spec/extensions/dry_schema/plugs/param_sanitization_handler_spec.rb
+++ b/spec/extensions/dry_schema/plugs/param_sanitization_handler_spec.rb
@@ -6,7 +6,7 @@ require 'web_pipe/extensions/dry_schema/plugs/param_sanitization_handler'
 RSpec.describe WebPipe::Plugs::ParamSanitizationHandler do
   describe '.[]' do
     it 'operation sets :param_sanitization_handler bag key' do
-      conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.(default_env)
       handler = ->(conn, _result) { conn }
       operation = described_class[handler]
 

--- a/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
+++ b/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
 
     context 'operation on success' do
       it "sets sanitized_params bag's key" do
-        env = DEFAULT_ENV.merge(Rack::QUERY_STRING => 'name=Joe')
+        env = default_env.merge(Rack::QUERY_STRING => 'name=Joe')
         conn = WebPipe::ConnSupport::Builder.(env)
         operation = described_class[schema]
 
@@ -39,7 +39,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
             taint
         end
         conn = WebPipe::ConnSupport::Builder.
-                 (DEFAULT_ENV).
+                 (default_env).
                  put(:param_sanitization_handler, configured_handler)
         operation = described_class[schema, injected_handler]
 
@@ -56,7 +56,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
             taint
         end
         conn = WebPipe::ConnSupport::Builder.
-                 (DEFAULT_ENV).
+                 (default_env).
                  put(:param_sanitization_handler, configured_handler)
         operation = described_class[schema]
 
@@ -66,7 +66,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
       end
 
       it 'uses default handler if none is injected nor configured' do
-        conn = WebPipe::ConnSupport::Builder.(DEFAULT_ENV)
+        conn = WebPipe::ConnSupport::Builder.(default_env)
         operation = described_class[schema]
 
         new_conn = operation.(conn)

--- a/spec/extensions/dry_view/dry_view_spec.rb
+++ b/spec/extensions/dry_view/dry_view_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WebPipe::Conn do
       view = Class.new(view_class) do
         config.template = 'template_without_input'
       end
-      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.call(default_env)
 
       new_conn = conn.view(view.new)
 
@@ -34,7 +34,7 @@ RSpec.describe WebPipe::Conn do
 
         expose :name
       end
-      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.call(default_env)
 
       new_conn = conn.view(view.new, name: 'Joe')
 
@@ -47,7 +47,7 @@ RSpec.describe WebPipe::Conn do
       end
       container = { 'view' => view.new }.freeze
       conn = WebPipe::ConnSupport::Builder.
-               call(DEFAULT_ENV).
+               call(default_env).
                put(:container, container)
 
       new_conn = conn.view('view')
@@ -68,7 +68,7 @@ RSpec.describe WebPipe::Conn do
         end.new
       end
       conn = WebPipe::ConnSupport::Builder.
-               call(DEFAULT_ENV).
+               call(default_env).
                put(:view_context, { name: 'Joe' })
 
       new_conn = conn.view(view.new)
@@ -86,7 +86,7 @@ RSpec.describe WebPipe::Conn do
         end
       end.new
       conn = WebPipe::ConnSupport::Builder.
-               call(DEFAULT_ENV).
+               call(default_env).
                put(:view_context, { name: 'Joe' })
 
       new_conn = conn.view(view.new, context: context)

--- a/spec/extensions/dry_view/plugs/view_context_spec.rb
+++ b/spec/extensions/dry_view/plugs/view_context_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WebPipe::Plugs::ViewContext do
   describe '.[]' do
     it "creates an operation which calls given proc with conn and sets result into bag's view_context key" do
       conn = WebPipe::ConnSupport::Builder.
-               call(DEFAULT_ENV).
+               call(default_env).
                put(:foo, 'bar')
       view_context_proc = ->(conn) { { foo: conn.fetch(:foo) } }
       plug = described_class[view_context_proc]

--- a/spec/extensions/flash/flash_spec.rb
+++ b/spec/extensions/flash/flash_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WebPipe::Conn do
   describe '#flash' do
     context "when rack-flash key is found in env" do
       it 'returns its value' do
-        env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+        env = default_env.merge('x-rack.flash' => flash)
         conn = WebPipe::ConnSupport::Builder.call(env)
 
         expect(conn.flash).to be(flash)
@@ -24,7 +24,7 @@ RSpec.describe WebPipe::Conn do
 
     context "when rack-flash key is not found in env" do
       it 'raises a MissingMiddlewareError' do
-        conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+        conn = WebPipe::ConnSupport::Builder.call(default_env)
 
         expect { conn.flash }.to raise_error(WebPipe::ConnSupport::MissingMiddlewareError)
       end
@@ -33,7 +33,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#put_flash' do
     it 'sets given key to given value in flash' do
-      env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+      env = default_env.merge('x-rack.flash' => flash)
       conn = WebPipe::ConnSupport::Builder.call(env)
 
       conn = conn.put_flash(:error, 'error')
@@ -44,7 +44,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#put_flash_now' do
     it 'sets given key to given value in flash cache' do
-      env = DEFAULT_ENV.merge('x-rack.flash' => flash)
+      env = default_env.merge('x-rack.flash' => flash)
       conn = WebPipe::ConnSupport::Builder.call(env)
 
       conn = conn.put_flash_now(:error, 'error')

--- a/spec/extensions/flash/integration/flash_spec.rb
+++ b/spec/extensions/flash/integration/flash_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe 'Using flash' do
   end
 
   it 'can put and read from flash' do
-    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Error now')
+    expect(pipe.call(default_env).last[0]).to eq('Error now')
   end
 end

--- a/spec/extensions/redirect/redirect_spec.rb
+++ b/spec/extensions/redirect/redirect_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WebPipe::Conn do
   before { WebPipe.load_extensions(:redirect) }
 
   describe '#redirect' do
-    let(:conn) { WebPipe::ConnSupport::Builder.(DEFAULT_ENV) }
+    let(:conn) { WebPipe::ConnSupport::Builder.(default_env) }
     let(:new_conn) { conn.redirect('/here') }
 
     it 'uses 302 as default status code' do

--- a/spec/extensions/session/session_spec.rb
+++ b/spec/extensions/session/session_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'support/env'
+require 'web_pipe'
+require 'web_pipe/conn_support/builder'
+
+RSpec.describe WebPipe::Conn do
+  before { WebPipe.load_extensions(:session) }
+
+  describe '#session' do
+    context 'when rack session key is found in env' do
+      it 'returns its value' do
+        session = {}
+        env = default_env.merge('rack.session' => session)
+        conn = WebPipe::ConnSupport::Builder.call(env)
+
+        expect(conn.session).to be(session)
+      end
+    end
+
+    context 'when rack session key is not found in env' do
+      it 'raises a MissingMiddlewareError' do
+        conn = WebPipe::ConnSupport::Builder.call(default_env)
+
+        expect { conn.session }.to raise_error(WebPipe::ConnSupport::MissingMiddlewareError)
+      end
+    end
+  end
+
+  describe '#fetch_session' do
+    it 'returns given item from session' do
+      env = default_env.merge('rack.session' => { 'foo' => 'bar' })
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      expect(conn.fetch_session('foo')).to eq('bar')
+    end
+
+    it 'returns default when not found' do
+      env = default_env.merge('rack.session' => {})
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      expect(conn.fetch_session('foo', 'bar')).to eq('bar')
+    end
+
+    it 'returns what block returns when key is not found and no default is given' do
+      env = default_env.merge('rack.session' => {})
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      expect(conn.fetch_session('foo') { 'bar' }).to eq('bar')
+    end
+  end
+
+  describe '#put_session' do
+    it 'adds given name/value pair to session' do
+      env = default_env.merge('rack.session' => {})
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      new_conn = conn.put_session('foo', 'bar')
+
+      expect(new_conn.session['foo']).to eq('bar')
+    end
+  end
+
+  describe '#delete_session' do
+    it 'deletes given name from the session' do
+      env = default_env.merge('rack.session' => { 'foo' => 'bar', 'bar' => 'foo' })
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      new_conn = conn.delete_session('foo')
+
+      expect(new_conn.session).to eq('bar' => 'foo')
+    end
+  end
+
+  describe '#clear_session' do
+    it 'resets session' do
+      env = default_env.merge('rack.session' => { 'foo' => 'bar' })
+      conn = WebPipe::ConnSupport::Builder.call(env)
+
+      new_conn = conn.clear_session
+
+      expect(new_conn.session).to eq({})
+    end
+  end
+end

--- a/spec/integration/composition_spec.rb
+++ b/spec/integration/composition_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe "Composition" do
   end
 
   it 'using a WebPipe composes its middlewares and plugs' do
-    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Hello Joe Doe')
+    expect(pipe.call(default_env).last[0]).to eq('Hello Joe Doe')
   end
 end

--- a/spec/integration/middleware_composition_spec.rb
+++ b/spec/integration/middleware_composition_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe "Middleware composition" do
   end
 
   it 'using a WebPipe composes its middlewares' do
-    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Hello Joe Doe')
+    expect(pipe.call(default_env).last[0]).to eq('Hello Joe Doe')
   end
 end

--- a/spec/integration/middleware_injection_spec.rb
+++ b/spec/integration/middleware_injection_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe "Injecting middlewares" do
   end
 
   it 'can use middlewares' do
-    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Hello Mr./Ms. Smith')
+    expect(pipe.call(default_env).last[0]).to eq('Hello Mr./Ms. Smith')
   end
 end

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe "Using rack middlewares" do
   end
 
   it 'can use middlewares' do
-    expect(pipe.call(DEFAULT_ENV).last[0]).to eq('Hello Joe Doe')
+    expect(pipe.call(default_env).last[0]).to eq('Hello Joe Doe')
   end
 end

--- a/spec/integration/plug_chaining_spec.rb
+++ b/spec/integration/plug_chaining_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe "Chaining plugs" do
   end
 
   it 'chains successful plugs' do
-    expect(pipe.call(DEFAULT_ENV).last).to eq(['OneTwo'])
+    expect(pipe.call(default_env).last).to eq(['OneTwo'])
   end
 end

--- a/spec/integration/plug_composition_spec.rb
+++ b/spec/integration/plug_composition_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe "Plug composition" do
   end
 
   it 'plugging a WebPipe composes its plug operations' do
-    expect(pipe.call(DEFAULT_ENV).last).to eq(['OneTwo'])
+    expect(pipe.call(default_env).last).to eq(['OneTwo'])
   end
 end

--- a/spec/integration/plug_from_container_spec.rb
+++ b/spec/integration/plug_from_container_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "Resolving plugs from a container" do
   end
 
   it 'can resolve operation from a container' do
-    expect(pipe.call(DEFAULT_ENV).last).to eq(['Hello, world!'])
+    expect(pipe.call(default_env).last).to eq(['Hello, world!'])
   end
 end

--- a/spec/integration/plug_from_method_spec.rb
+++ b/spec/integration/plug_from_method_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "Resolving plugs from a method" do
   end
 
   it 'can resolve operation from an internal method' do
-    expect(pipe.call(DEFAULT_ENV).last).to eq(['Hello, world!'])
+    expect(pipe.call(default_env).last).to eq(['Hello, world!'])
   end
 end

--- a/spec/integration/plug_injection_spec.rb
+++ b/spec/integration/plug_injection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Plug injection" do
     pipe_with_injection = pipe.new(plugs: { hello: hello })
 
     expect(
-      pipe_with_injection.call(DEFAULT_ENV).last
+      pipe_with_injection.call(default_env).last
     ).to eq(['Hello, injected world!'])
   end
 end

--- a/spec/integration/plug_tainting_spec.rb
+++ b/spec/integration/plug_tainting_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe "Plug tainting" do
   end
 
   it 'dirty plugs stops the pipe' do
-    expect(pipe.call(DEFAULT_ENV).last).to eq(['Dirty'])
+    expect(pipe.call(default_env).last).to eq(['Dirty'])
   end
 end

--- a/spec/support/env.rb
+++ b/spec/support/env.rb
@@ -1,17 +1,19 @@
 require 'rack'
 
-DEFAULT_ENV = {
-  Rack::RACK_VERSION      => Rack::VERSION,
-  Rack::RACK_INPUT        => StringIO.new,
-  Rack::RACK_ERRORS       => StringIO.new,
-  Rack::RACK_MULTITHREAD  => true,
-  Rack::RACK_MULTIPROCESS => true,
-  Rack::RACK_RUNONCE      => false,
-  Rack::RACK_URL_SCHEME   => 'http',
+def default_env
+  {
+    Rack::RACK_VERSION      => Rack::VERSION,
+    Rack::RACK_INPUT        => StringIO.new,
+    Rack::RACK_ERRORS       => StringIO.new,
+    Rack::RACK_MULTITHREAD  => true,
+    Rack::RACK_MULTIPROCESS => true,
+    Rack::RACK_RUNONCE      => false,
+    Rack::RACK_URL_SCHEME   => 'http',
 
-  # PEP333
-  Rack::REQUEST_METHOD    => Rack::GET,
-  Rack::QUERY_STRING      => '',
-  Rack::SERVER_NAME       => 'www.example.org',
-  Rack::SERVER_PORT       => '80'
-}
+    # PEP333
+    Rack::REQUEST_METHOD    => Rack::GET,
+    Rack::QUERY_STRING      => '',
+    Rack::SERVER_NAME       => 'www.example.org',
+    Rack::SERVER_PORT       => '80'
+  }
+end

--- a/spec/unit/web_pipe/app_spec.rb
+++ b/spec/unit/web_pipe/app_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebPipe::App do
 
       app = described_class.new([op_1, op_2])
 
-      expect(app.call(DEFAULT_ENV)).to eq([200, {}, ['foo']])
+      expect(app.call(default_env)).to eq([200, {}, ['foo']])
     end
 
     it 'stops chain propagation once a conn is tainted' do
@@ -22,7 +22,7 @@ RSpec.describe WebPipe::App do
 
       app = described_class.new([op_1, op_2, op_3, op_4])
 
-      expect(app.call(DEFAULT_ENV)).to eq([200, {}, ['foo']])
+      expect(app.call(default_env)).to eq([200, {}, ['foo']])
     end
 
     it 'raises InvalidOperationReturn when one operation does not return a Conn' do
@@ -31,7 +31,7 @@ RSpec.describe WebPipe::App do
       app = described_class.new([op])
 
       expect {
-        app.call(DEFAULT_ENV)
+        app.call(default_env)
       }.to raise_error(
              WebPipe::ConnSupport::Composition::InvalidOperationResult
       )

--- a/spec/unit/web_pipe/conn_spec.rb
+++ b/spec/unit/web_pipe/conn_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#base_url' do
     it 'returns request base url' do
-      env = DEFAULT_ENV.merge(
+      env = default_env.merge(
         Rack::HTTPS => 'on',
         Rack::HTTP_HOST => 'www.host.org',
         Rack::SERVER_PORT => '8000',
@@ -24,7 +24,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#path' do
     it 'returns request path' do
-      env = DEFAULT_ENV.merge(
+      env = default_env.merge(
         Rack::SCRIPT_NAME => 'index.rb',
         Rack::PATH_INFO => '/foo'
       )
@@ -37,7 +37,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#full_path' do
     it 'returns request fullpath' do
-      env = DEFAULT_ENV.merge(
+      env = default_env.merge(
         Rack::PATH_INFO => '/foo',
         Rack::QUERY_STRING => 'foo=bar',
       )
@@ -50,7 +50,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#url' do
     it 'returns request url' do
-      env = DEFAULT_ENV.merge(
+      env = default_env.merge(
         Rack::HTTPS => 'on',
         Rack::HTTP_HOST => 'www.host.org',
         Rack::PATH_INFO => '/home',
@@ -66,7 +66,7 @@ RSpec.describe WebPipe::Conn do
 
   describe '#params' do
     it 'returns request params' do
-      env = DEFAULT_ENV.merge(
+      env = default_env.merge(
         Rack::QUERY_STRING => 'foo=bar'
       )
 
@@ -78,7 +78,7 @@ RSpec.describe WebPipe::Conn do
 
   describe 'set_status' do
     it 'sets status' do
-      conn = build(DEFAULT_ENV)
+      conn = build(default_env)
 
       new_conn = conn.set_status(404)
 
@@ -89,7 +89,7 @@ RSpec.describe WebPipe::Conn do
   describe 'set_response_body' do
     context 'when value is a string' do
       it 'sets response body as one item array of given value' do
-        conn = build(DEFAULT_ENV).new(response_body: ['foo'])
+        conn = build(default_env).new(response_body: ['foo'])
 
         new_conn = conn.set_response_body('bar')
 
@@ -99,7 +99,7 @@ RSpec.describe WebPipe::Conn do
 
     context 'when value responds to :each' do
       it 'it substitutes whole response_body' do
-        conn = build(DEFAULT_ENV).new(response_body: ['foo'])
+        conn = build(default_env).new(response_body: ['foo'])
 
         new_conn = conn.set_response_body(['bar', 'var'])
 
@@ -110,7 +110,7 @@ RSpec.describe WebPipe::Conn do
 
   describe 'add_response_header' do
     it 'adds given pair to response headers' do
-      conn = build(DEFAULT_ENV).new(
+      conn = build(default_env).new(
         response_headers: { 'Foo' => 'Foo' }
       )
 
@@ -124,7 +124,7 @@ RSpec.describe WebPipe::Conn do
 
   describe 'delete_response_header' do
     it 'deletes response header with given key' do
-      conn = build(DEFAULT_ENV).new(
+      conn = build(default_env).new(
         response_headers: { 'Foo' => 'Bar', 'Zoo-Zoo' => 'Zar' }
       )
 
@@ -136,13 +136,13 @@ RSpec.describe WebPipe::Conn do
 
   describe 'fetch' do
     it 'returns item in bag with given key' do
-      conn = build(DEFAULT_ENV).new(bag: { foo: :bar })
+      conn = build(default_env).new(bag: { foo: :bar })
 
       expect(conn.fetch(:foo)).to be(:bar)
     end
 
     it 'raises KeyNotFoundInBagError when key does not exist' do
-      conn = build(DEFAULT_ENV)
+      conn = build(default_env)
       
       expect {
         conn.fetch(:foo)
@@ -150,7 +150,7 @@ RSpec.describe WebPipe::Conn do
     end
 
     it 'returns default when it is given and key does not exist' do
-      conn = build(DEFAULT_ENV)
+      conn = build(default_env)
 
       expect(conn.fetch(:foo, :bar)).to be(:bar)
     end
@@ -158,7 +158,7 @@ RSpec.describe WebPipe::Conn do
 
   describe 'put' do
     it 'sets key/value pair in bag' do
-      conn = build(DEFAULT_ENV)
+      conn = build(default_env)
 
       new_conn = conn.put(:foo, :bar)
 
@@ -167,7 +167,7 @@ RSpec.describe WebPipe::Conn do
   end
 
   describe '#rack_response' do
-    let(:env) { DEFAULT_ENV.merge(Rack::RACK_SESSION => { "foo" => "bar" }) }
+    let(:env) { default_env.merge(Rack::RACK_SESSION => { "foo" => "bar" }) }
     let(:conn) do
       conn = build(env)
       conn.

--- a/spec/unit/web_pipe/conn_support/builder_spec.rb
+++ b/spec/unit/web_pipe/conn_support/builder_spec.rb
@@ -6,24 +6,24 @@ require 'support/env'
 RSpec.describe WebPipe::ConnSupport::Builder do
   describe ".call" do
     it 'creates a Conn::Clean' do
-      conn = described_class.call(DEFAULT_ENV)
+      conn = described_class.call(default_env)
 
       expect(conn).to be_an_instance_of(WebPipe::Conn::Clean)
     end
 
     context 'env' do
       it 'fills in with rack env' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
-        expect(conn.env).to be(DEFAULT_ENV)
+        expect(conn.env).to be(env)
       end
     end
 
     context 'request' do
       it 'fills in with rack request' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
@@ -33,7 +33,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'scheme' do
       it 'fills with request scheme as symbol' do
-        env = DEFAULT_ENV.merge(Rack::HTTPS => 'on')
+        env = default_env.merge(Rack::HTTPS => 'on')
 
         conn = described_class.call(env)
 
@@ -43,7 +43,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'request_method' do
       it 'fills in with downcased request method as symbol' do
-        env = DEFAULT_ENV.merge(Rack::REQUEST_METHOD => 'POST')
+        env = default_env.merge(Rack::REQUEST_METHOD => 'POST')
 
         conn = described_class.call(env)
 
@@ -53,7 +53,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'host' do
       it 'fills in with request host' do
-        env = DEFAULT_ENV.merge(Rack::HTTP_HOST => 'www.host.org')
+        env = default_env.merge(Rack::HTTP_HOST => 'www.host.org')
 
         conn = described_class.call(env)
 
@@ -63,7 +63,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'ip' do
       it 'fills in with request ip' do
-        env = DEFAULT_ENV.merge('REMOTE_ADDR' => '0.0.0.0')
+        env = default_env.merge('REMOTE_ADDR' => '0.0.0.0')
 
         conn = described_class.call(env)
 
@@ -71,7 +71,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
       end
 
       it 'defaults to nil' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
@@ -81,7 +81,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'port' do
       it 'fills in with request port' do
-        env = DEFAULT_ENV.merge(Rack::SERVER_PORT => '443')
+        env = default_env.merge(Rack::SERVER_PORT => '443')
 
         conn = described_class.call(env)
 
@@ -91,7 +91,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'script_name' do
       it 'fills in with request script name' do
-        env = DEFAULT_ENV.merge(Rack::SCRIPT_NAME => 'index.rb')
+        env = default_env.merge(Rack::SCRIPT_NAME => 'index.rb')
 
         conn = described_class.call(env)
 
@@ -101,7 +101,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'path_info' do
       it 'fills in with request path info' do
-        env = DEFAULT_ENV.merge(Rack::PATH_INFO => '/foo/bar')
+        env = default_env.merge(Rack::PATH_INFO => '/foo/bar')
 
         conn = described_class.call(env)
 
@@ -111,7 +111,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'query_string' do
       it 'fills in with request query string' do
-        env = DEFAULT_ENV.merge(Rack::QUERY_STRING => 'foo=bar')
+        env = default_env.merge(Rack::QUERY_STRING => 'foo=bar')
 
         conn = described_class.call(env)
 
@@ -122,7 +122,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
     context 'request_body' do
       it 'fills in with request body' do
         request_body = StringIO.new('foo=bar')
-        env = DEFAULT_ENV.merge(
+        env = default_env.merge(
           Rack::RACK_INPUT => request_body
         )
 
@@ -134,7 +134,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     describe '#request_headers' do
       it 'fills in with extracted headers from env' do
-        env = DEFAULT_ENV.merge('HTTP_FOO_BAR' => 'BAR')
+        env = default_env.merge('HTTP_FOO_BAR' => 'BAR')
 
         conn = described_class.call(env)
 
@@ -144,7 +144,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'status' do
       it 'let it to initialize with its default' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
@@ -154,7 +154,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'response_body' do
       it 'let it to initialize with its default' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
@@ -164,7 +164,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
     context 'response_headers' do
       it 'let it to initialize with its default' do
-        env = DEFAULT_ENV
+        env = default_env
 
         conn = described_class.call(env)
 
@@ -175,7 +175,7 @@ RSpec.describe WebPipe::ConnSupport::Builder do
 
   context 'bag' do
     it 'let it to initialize with its default' do
-      env = DEFAULT_ENV
+      env = default_env
 
       conn = described_class.call(env)
 

--- a/spec/unit/web_pipe/conn_support/composition_spec.rb
+++ b/spec/unit/web_pipe/conn_support/composition_spec.rb
@@ -4,7 +4,7 @@ require 'web_pipe/conn_support/composition'
 require 'web_pipe/conn_support/builder'
 
 RSpec.describe WebPipe::ConnSupport::Composition do
-  let(:conn) { WebPipe::ConnSupport::Builder.call(DEFAULT_ENV) }
+  let(:conn) { WebPipe::ConnSupport::Builder.call(default_env) }
   
   describe '#call' do
     it 'chains operations on Conn' do

--- a/spec/unit/web_pipe/conn_support/headers_spec.rb
+++ b/spec/unit/web_pipe/conn_support/headers_spec.rb
@@ -5,7 +5,7 @@ require 'web_pipe/conn_support/headers'
 RSpec.describe WebPipe::ConnSupport::Headers do
   describe '.extract' do
     it 'returns hash with env HTTP_ pairs with prefix removed' do
-      env = DEFAULT_ENV.merge('HTTP_F' => 'BAR')
+      env = default_env.merge('HTTP_F' => 'BAR')
 
       headers = described_class.extract(env)
 
@@ -13,7 +13,7 @@ RSpec.describe WebPipe::ConnSupport::Headers do
     end
 
     it 'normalize keys' do
-      env = DEFAULT_ENV.merge('HTTP_FOO_BAR' => 'foobar')
+      env = default_env.merge('HTTP_FOO_BAR' => 'foobar')
 
       headers = described_class.extract(env)
 
@@ -21,7 +21,7 @@ RSpec.describe WebPipe::ConnSupport::Headers do
     end
 
     it 'includes content type CGI-like var' do
-      env = DEFAULT_ENV.merge('CONTENT_TYPE' => 'text/html')
+      env = default_env.merge('CONTENT_TYPE' => 'text/html')
 
       headers = described_class.extract(env)
 
@@ -29,7 +29,7 @@ RSpec.describe WebPipe::ConnSupport::Headers do
     end
 
     it 'includes content length CGI-like var' do
-      env = DEFAULT_ENV.merge('CONTENT_LENGTH' => '10')
+      env = default_env.merge('CONTENT_LENGTH' => '10')
 
       headers = described_class.extract(env)
 
@@ -37,7 +37,7 @@ RSpec.describe WebPipe::ConnSupport::Headers do
     end
 
     it 'defaults to empty hash' do
-      headers = described_class.extract(DEFAULT_ENV)
+      headers = described_class.extract(default_env)
 
       expect(headers).to eq({})
     end

--- a/spec/unit/web_pipe/plugs/content_type_spec.rb
+++ b/spec/unit/web_pipe/plugs/content_type_spec.rb
@@ -6,7 +6,7 @@ require 'web_pipe/conn_support/builder'
 RSpec.describe WebPipe::Plugs::ContentType do
   describe '.[]' do
     it "creates an operation which adds given argument as Content-Type header" do
-      conn = WebPipe::ConnSupport::Builder.call(DEFAULT_ENV)
+      conn = WebPipe::ConnSupport::Builder.call(default_env)
       plug = described_class['text/html']
 
       new_conn = plug.(conn)


### PR DESCRIPTION
Wrapper around Rack::Session middlewares.

This extension provides with helper methods to retrieve rack
session and work with it while still being able to chain `Conn`
method calls.

It requires one of `Rack::Session` middlewares to be present.

```ruby
require 'web_pipe'

WebPipe.load_extensions(:session)

class MyApp
  include WebPipe

  use Rack::Cookie, secret: 'top_secret'

  plug :put_session, ->(conn) { conn.put_session('foo', 'bar') }
  plug :fetch_session, ->(conn) { conn.put(:foo, conn.fetch_session('foo')) }
  plug :delete_session, ->(conn) { conn.delete_session('foo') }
  plug :clear_session, ->(conn) { conn.clear_session }
end
```