### PR TITLE
Merge GET and POST parameters whin router parameters

### DIFF
--- a/lib/web_pipe/conn.rb
+++ b/lib/web_pipe/conn.rb
@@ -32,6 +32,11 @@ module WebPipe
   class Conn < Dry::Struct
     include ConnSupport::Types
 
+    # Env's key used to retrieve params set by the router.
+    #
+    # @see #router_params
+    ROUTER_PARAMS_KEY = 'router.params'
+
     # @!attribute [r] env
     #
     # Rack env hash.
@@ -260,14 +265,31 @@ module WebPipe
       request.url
     end
 
-    # GET and POST params merged in a hash.
+    # *Params* in rack env's 'router.params' key.
+    #
+    # Routers used to map routes to applications build with
+    # {WebPipe} have the option to introduce extra params through
+    # setting env's 'router.params' key. These parameters will be
+    # merged with GET and POST ones when calling {#params}.
+    #
+    # This kind of functionality is usually implemented from the
+    # router side allowing the addition of variables in the route
+    # definition, e.g.:
+    #
+    # @example
+    #   /user/:id/update
+    def router_params
+      env.fetch(ROUTER_PARAMS_KEY, Types::EMPTY_HASH)
+    end
+
+    # GET, POST and {#router_params} merged in a hash.
     #
     # @return [Params]
     #
     # @example
-    #   { 'id' => 1, 'name' => 'Joe' }
+    #   { 'id' => '1', 'name' => 'Joe' }
     def params
-      request.params
+      request.params.merge(router_params)
     end
 
     # Sets response status code.

--- a/spec/unit/web_pipe/conn_spec.rb
+++ b/spec/unit/web_pipe/conn_spec.rb
@@ -64,8 +64,26 @@ RSpec.describe WebPipe::Conn do
     end
   end
 
+  describe '#router_params' do
+    it "returns env's router.params key" do
+      env = default_env.merge(
+        'router.params' => { 'id' => '1' }
+      )
+
+      conn = build(env)
+
+      expect(conn.router_params).to eq({ 'id' => '1' })
+    end
+
+    it "returns empty hash when key is not present" do
+      conn = build(default_env)
+
+      expect(conn.router_params).to eq({})
+    end
+  end
+
   describe '#params' do
-    it 'returns request params' do
+    it 'includes request params' do
       env = default_env.merge(
         Rack::QUERY_STRING => 'foo=bar'
       )
@@ -73,6 +91,17 @@ RSpec.describe WebPipe::Conn do
       conn = build(env)
 
       expect(conn.params).to eq({ 'foo' => 'bar'})
+    end
+
+    it "includes router params" do
+      env = default_env.merge(
+        Rack::QUERY_STRING => 'foo=bar',
+        'router.params' => { 'id' => '1' }
+      )
+
+      conn = build(env)
+
+      expect(conn.params).to eq({ 'foo' => 'bar', 'id' => '1'})
     end
   end
 


### PR DESCRIPTION
If the router used populates env's "router.params" key, these parameters
will be merged with GET and POST parameters when calling '#params'.
Choosing this key automatically integrates with hanami-router.