### PR TITLE
Rename `put` methods to `add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class GreetingAdminApp
     user = UsersRepo[conn.params['id'].to_i]
     if user
       conn.
-        put(:user, user)
+        add(:user, user)
     else
       conn.
         set_status(404).
@@ -151,7 +151,7 @@ the pipe will be in command of the web response.
 
 Operations have the chance to prepare data to be consumed by
 downstream operations. Data can be added to the struct through
-`#put(key, value)`, while it can be consumed with `#fetch(key)`.
+`#add(key, value)`, while it can be consumed with `#fetch(key)`.
 
 Attributes and methods in `WebPipe::Conn` are [fully
 documented](https://www.rubydoc.info/github/waiting-for-dev/web_pipe/master/WebPipe/Conn).

--- a/lib/web_pipe/conn.rb
+++ b/lib/web_pipe/conn.rb
@@ -296,7 +296,7 @@ module WebPipe
     # @param value [Object]
     #
     # @return [Conn]
-    def put(key, value)
+    def add(key, value)
       new(
         bag: bag.merge(key => value)
       )

--- a/lib/web_pipe/extensions/container/plugs/container.rb
+++ b/lib/web_pipe/extensions/container/plugs/container.rb
@@ -19,12 +19,12 @@ module WebPipe
     #     private
     #
     #     def resolve(conn)
-    #       conn.put(:dependency, conn.fetch(:container)[:name])
+    #       conn.add(:dependency, conn.fetch(:container)[:name])
     #     end
     #   end
     module Container
       def self.[](container)
-        ->(conn) { conn.put(:container, Types::Container[container]) }
+        ->(conn) { conn.add(:container, Types::Container[container]) }
       end
     end
   end

--- a/lib/web_pipe/extensions/dry_schema/plugs/param_sanitization_handler.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/param_sanitization_handler.rb
@@ -19,7 +19,7 @@ module WebPipe
       # @return [ConnSupport::Composition::Operation[]]
       def self.[](handler)
         lambda do |conn|
-          conn.put(PARAM_SANITIZATION_HANDLER_KEY, Handler[handler])
+          conn.add(PARAM_SANITIZATION_HANDLER_KEY, Handler[handler])
         end
       end
     end

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -26,7 +26,7 @@ module WebPipe
         lambda do |conn|
           result = schema.(conn.params)
           if result.success?
-            conn.put(DrySchema::SANITIZED_PARAMS_KEY, result.output)
+            conn.add(DrySchema::SANITIZED_PARAMS_KEY, result.output)
           else
             get_handler(conn, handler).(conn, result)
           end

--- a/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
+++ b/lib/web_pipe/extensions/dry_view/plugs/view_context.rb
@@ -3,7 +3,7 @@ require 'web_pipe/extensions/dry_view/dry_view'
 
 module WebPipe
   module Plugs
-    # Calls object with conn and puts the result into bag's `:view_context`.
+    # Calls object with conn and add the result into bag's `:view_context`.
     #
     # This is meant to contain a Proc which will be called with the same
     # {WebPipe::Conn} instance of the operation. It must return
@@ -30,7 +30,7 @@ module WebPipe
       def self.[](view_context_proc)
         Types.Interface(:call)[view_context_proc]
         lambda do |conn|
-          conn.put(Conn::VIEW_CONTEXT_KEY, view_context_proc.(conn))
+          conn.add(Conn::VIEW_CONTEXT_KEY, view_context_proc.(conn))
         end
       end
     end

--- a/lib/web_pipe/extensions/flash/flash.rb
+++ b/lib/web_pipe/extensions/flash/flash.rb
@@ -19,8 +19,8 @@ module WebPipe
   #     use :session, Rack::Session::Cookie, secret: 'secret'
   #     use :flash, Rack::Flash
   #
-  #     plug :put_in_flash, ->(conn) { conn.put_flash(:notice, 'Hello world') }
-  #     plug :put_in_flash_now, ->(conn) { conn.put_flash_now(:notice_now, 'Hello world now') }
+  #     plug :add_in_flash, ->(conn) { conn.add_flash(:notice, 'Hello world') }
+  #     plug :add_in_flash_now, ->(conn) { conn.add_flash_now(:notice_now, 'Hello world now') }
   #   end
   #
   # Usually, you will end up making `conn.flash` available to your view system:
@@ -52,21 +52,21 @@ module WebPipe
       end
     end
 
-    # Puts an item to the flash bag to be consumed by next request.
+    # Adds an item to the flash bag to be consumed by next request.
     #
     # @param key [String]
     # @param value [String]
-    def put_flash(key, value)
+    def add_flash(key, value)
       flash[key] = value
       self
     end
 
-    # Puts an item to the flash bag to be consumed by the same request
+    # Adds an item to the flash bag to be consumed by the same request
     # in process.
     #
     # @param key [String]
     # @param value [String]
-    def put_flash_now(key, value)
+    def add_flash_now(key, value)
       flash.now[key] = value
       self
     end

--- a/lib/web_pipe/extensions/session/session.rb
+++ b/lib/web_pipe/extensions/session/session.rb
@@ -21,8 +21,8 @@ module WebPipe
   #
   #     use Rack::Cookie, secret: 'top_secret'
   #
-  #     plug :put_session, ->(conn) { conn.put_session('foo', 'bar') }
-  #     plug :fetch_session, ->(conn) { conn.put(:foo, conn.fetch_session('foo')) }
+  #     plug :add_session, ->(conn) { conn.add_session('foo', 'bar') }
+  #     plug :fetch_session, ->(conn) { conn.add(:foo, conn.fetch_session('foo')) }
   #     plug :delete_session, ->(conn) { conn.delete_session('foo') }
   #     plug :clear_session, ->(conn) { conn.clear_session }
   #   end
@@ -54,12 +54,12 @@ module WebPipe
     end
 
 
-    # Puts given key/value pair to the session.
+    # Adds given key/value pair to the session.
     #
     # @param key [SESSION_KEY[]] Session key
     # @param value [Any] Value
     # @return [Conn]
-    def put_session(key, value)
+    def add_session(key, value)
       session[SESSION_KEY[key]] = value
       self
     end

--- a/spec/extensions/container/container_spec.rb
+++ b/spec/extensions/container/container_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebPipe::Conn do
       conn = build_conn(default_env)
       container = {}.freeze
 
-      new_conn = conn.put(:container, container)
+      new_conn = conn.add(:container, container)
 
       expect(new_conn.container).to be(container)
     end

--- a/spec/extensions/dry_schema/dry_schema_spec.rb
+++ b/spec/extensions/dry_schema/dry_schema_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebPipe::Conn do
       conn = WebPipe::ConnSupport::Builder.(default_env)
       sanitized_params = {}.freeze
 
-      new_conn = conn.put(:sanitized_params, sanitized_params)
+      new_conn = conn.add(:sanitized_params, sanitized_params)
 
       expect(new_conn.sanitized_params).to be(sanitized_params)
     end

--- a/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
+++ b/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
         end
         conn = WebPipe::ConnSupport::Builder.
                  (default_env).
-                 put(:param_sanitization_handler, configured_handler)
+                 add(:param_sanitization_handler, configured_handler)
         operation = described_class[schema, injected_handler]
 
         new_conn = operation.(conn)
@@ -57,7 +57,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
         end
         conn = WebPipe::ConnSupport::Builder.
                  (default_env).
-                 put(:param_sanitization_handler, configured_handler)
+                 add(:param_sanitization_handler, configured_handler)
         operation = described_class[schema]
 
         new_conn = operation.(conn)

--- a/spec/extensions/dry_view/dry_view_spec.rb
+++ b/spec/extensions/dry_view/dry_view_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe WebPipe::Conn do
       container = { 'view' => view.new }.freeze
       conn = WebPipe::ConnSupport::Builder.
                call(default_env).
-               put(:container, container)
+               add(:container, container)
 
       new_conn = conn.view('view')
 
@@ -69,7 +69,7 @@ RSpec.describe WebPipe::Conn do
       end
       conn = WebPipe::ConnSupport::Builder.
                call(default_env).
-               put(:view_context, { name: 'Joe' })
+               add(:view_context, { name: 'Joe' })
 
       new_conn = conn.view(view.new)
 
@@ -87,7 +87,7 @@ RSpec.describe WebPipe::Conn do
       end.new
       conn = WebPipe::ConnSupport::Builder.
                call(default_env).
-               put(:view_context, { name: 'Joe' })
+               add(:view_context, { name: 'Joe' })
 
       new_conn = conn.view(view.new, context: context)
 

--- a/spec/extensions/dry_view/plugs/view_context_spec.rb
+++ b/spec/extensions/dry_view/plugs/view_context_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WebPipe::Plugs::ViewContext do
     it "creates an operation which calls given proc with conn and sets result into bag's view_context key" do
       conn = WebPipe::ConnSupport::Builder.
                call(default_env).
-               put(:foo, 'bar')
+               add(:foo, 'bar')
       view_context_proc = ->(conn) { { foo: conn.fetch(:foo) } }
       plug = described_class[view_context_proc]
 

--- a/spec/extensions/flash/flash_spec.rb
+++ b/spec/extensions/flash/flash_spec.rb
@@ -31,23 +31,23 @@ RSpec.describe WebPipe::Conn do
     end
   end
 
-  describe '#put_flash' do
+  describe '#add_flash' do
     it 'sets given key to given value in flash' do
       env = default_env.merge('x-rack.flash' => flash)
       conn = build_conn(env)
 
-      conn = conn.put_flash(:error, 'error')
+      conn = conn.add_flash(:error, 'error')
 
       expect(flash[:error]).to eq('error')
     end
   end
 
-  describe '#put_flash_now' do
+  describe '#add_flash_now' do
     it 'sets given key to given value in flash cache' do
       env = default_env.merge('x-rack.flash' => flash)
       conn = build_conn(env)
 
-      conn = conn.put_flash_now(:error, 'error')
+      conn = conn.add_flash_now(:error, 'error')
 
       expect(flash.send(:cache)[:error]).to eq('error')
     end

--- a/spec/extensions/flash/integration/flash_spec.rb
+++ b/spec/extensions/flash/integration/flash_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe 'Using flash' do
       use :session, ::Rack::Session::Cookie, secret: 'secret'
       use :flash, ::Rack::Flash
 
-      plug :put_in_flash
+      plug :add_to_flash
       plug :build_response
 
       private
 
-      def put_in_flash(conn)
+      def add_to_flash(conn)
         conn.
-          put_flash(:error, 'Error').
-          put_flash_now(:now, 'now')
+          add_flash(:error, 'Error').
+          add_flash_now(:now, 'now')
       end
 
       def build_response(conn)
@@ -33,7 +33,7 @@ RSpec.describe 'Using flash' do
     end.new
   end
 
-  it 'can put and read from flash' do
+  it 'can adadd and read from flash' do
     expect(pipe.call(default_env).last[0]).to eq('Error now')
   end
 end

--- a/spec/extensions/session/session_spec.rb
+++ b/spec/extensions/session/session_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe WebPipe::Conn do
     end
   end
 
-  describe '#put_session' do
+  describe '#add_session' do
     it 'adds given name/value pair to session' do
       env = default_env.merge('rack.session' => {})
       conn = build_conn(env)
 
-      new_conn = conn.put_session('foo', 'bar')
+      new_conn = conn.add_session('foo', 'bar')
 
       expect(new_conn.session['foo']).to eq('bar')
     end

--- a/spec/integration/composition_spec.rb
+++ b/spec/integration/composition_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Composition" do
 
     use :first_name, FirstNameMiddleware
 
-    plug :gretting, ->(conn) { conn.put(:greeting, 'Hello') }
+    plug :gretting, ->(conn) { conn.add(:greeting, 'Hello') }
   end
 
   let(:pipe) do

--- a/spec/unit/web_pipe/conn_spec.rb
+++ b/spec/unit/web_pipe/conn_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe WebPipe::Conn do
     end
   end
 
-  describe 'put' do
-    it 'sets key/value pair in bag' do
+  describe 'add' do
+    it 'adds key/value pair to bag' do
       conn = build(default_env)
 
-      new_conn = conn.put(:foo, :bar)
+      new_conn = conn.add(:foo, :bar)
 
       expect(new_conn.bag[:foo]).to be(:bar)
     end


### PR DESCRIPTION
This is more idiomatic in Ruby.

Methods renamed are:

- `Conn#put` -> `Conn#add`
- Flash extension: `Conn#put_flash` -> `Conn#add_flash`
- Flash extension: `Conn#put_flash_now` -> `Conn#add_flash_now`
- Session extension: `Conn#put_session` -> `Conn#add_session`