### PR TITLE
Fix support for ruby 2.4

### DIFF
--- a/lib/web_pipe/conn_support/headers.rb
+++ b/lib/web_pipe/conn_support/headers.rb
@@ -97,7 +97,9 @@ module WebPipe
       #
       # @see #normalize_key
       def self.normalize(headers)
-        headers.transform_keys(&method(:normalize_key))
+        Hash[
+          headers.map { |k, v| [normalize_key(k), v] }
+        ]
       end
     end
   end


### PR DESCRIPTION
Ruby 2.4 doesn't have Hash#transform_keys, so implementation has been
changed.