### PR TITLE
Change interface from `.[]` to `.()` for plugs

### DIFF
--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -59,7 +59,7 @@ module WebPipe
   #    Schema = Dry::Schema.Params { ... }
   #
   #    plug :app, App.new
-  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
+  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams.call(Schema)
   #  end
   #
   # @see https://dry-rb.org/gems/dry-schema/

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -26,7 +26,7 @@ module WebPipe
       # @param handler [ParamSanitizationHandler::Handler[]]
       #
       # @return [ConnSupport::Composition::Operation[], Types::Undefined]
-      def self.[](schema, handler = Types::Undefined)
+      def self.call(schema, handler = Types::Undefined)
         lambda do |conn|
           result = schema.(conn.params)
           if result.success?

--- a/lib/web_pipe/plugs/config.rb
+++ b/lib/web_pipe/plugs/config.rb
@@ -10,10 +10,10 @@ module WebPipe
     #   class App
     #     include WebPipe
     #
-    #     plug :config, WebPipe::Plugs::Config[foo: :bar]
+    #     plug :config, WebPipe::Plugs::Config.(foo: :bar)
     #   end
     module Config
-      def self.[](pairs)
+      def self.call(pairs)
         lambda do |conn|
           conn.new(
             config: conn.config.merge(pairs)

--- a/lib/web_pipe/plugs/content_type.rb
+++ b/lib/web_pipe/plugs/content_type.rb
@@ -10,13 +10,13 @@ module WebPipe
     #   class App
     #     include WebPipe
     #
-    #     plug :html, WebPipe::Plugs::ContentType['text/html']
+    #     plug :html, WebPipe::Plugs::ContentType.call('text/html')
     #   end
     module ContentType
       # Content-Type header
       HEADER = 'Content-Type'
 
-      def self.[](content_type)
+      def self.call(content_type)
         ->(conn) { conn.add_response_header(HEADER, content_type) }
       end
     end

--- a/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
+++ b/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
@@ -5,7 +5,7 @@ require 'web_pipe/extensions/dry_schema/plugs/sanitize_params'
 require 'web_pipe/conn_support/builder'
 
 RSpec.describe WebPipe::Plugs::SanitizeParams do
-  describe '.[]' do
+  describe '.call' do
     let(:schema) do
       schema = Dry::Schema.Params do
         required(:name)
@@ -16,7 +16,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
       it "sets sanitized_params bag's key" do
         env = default_env.merge(Rack::QUERY_STRING => 'name=Joe')
         conn = WebPipe::ConnSupport::Builder.(env)
-        operation = described_class[schema]
+        operation = described_class.(schema)
 
         new_conn = operation.(conn)
 
@@ -41,7 +41,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
         conn = WebPipe::ConnSupport::Builder.
                  (default_env).
                  add_config(:param_sanitization_handler, configured_handler)
-        operation = described_class[schema, injected_handler]
+        operation = described_class.(schema, injected_handler)
 
         new_conn = operation.(conn)
 
@@ -58,7 +58,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
         conn = WebPipe::ConnSupport::Builder.
                  (default_env).
                  add_config(:param_sanitization_handler, configured_handler)
-        operation = described_class[schema]
+        operation = described_class.(schema)
 
         new_conn = operation.(conn)
 
@@ -68,7 +68,7 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
 
       it 'uses default handler if none is injected nor configured' do
         conn = WebPipe::ConnSupport::Builder.(default_env)
-        operation = described_class[schema]
+        operation = described_class.(schema)
 
         new_conn = operation.(conn)
 

--- a/spec/unit/web_pipe/plugs/config_spec.rb
+++ b/spec/unit/web_pipe/plugs/config_spec.rb
@@ -3,15 +3,15 @@ require 'support/conn'
 require 'web_pipe/plugs/config'
 
 RSpec.describe WebPipe::Plugs::Config do
-  describe '.[]' do
+  describe '.call' do
     it "creates an operation which adds given pairs to config" do
       conn = build_conn(default_env).add_config(:zoo, :zoo)
-      plug = described_class[
+      operation = described_class.(
         foo: :bar,
         rar: :ror
-      ]
+      )
 
-      new_conn = plug.(conn)
+      new_conn = operation.(conn)
 
       expect(new_conn.config).to eq(zoo: :zoo, foo: :bar, rar: :ror)
     end

--- a/spec/unit/web_pipe/plugs/content_type_spec.rb
+++ b/spec/unit/web_pipe/plugs/content_type_spec.rb
@@ -4,12 +4,12 @@ require 'web_pipe/plugs/content_type'
 require 'web_pipe/conn_support/builder'
 
 RSpec.describe WebPipe::Plugs::ContentType do
-  describe '.[]' do
+  describe '.call' do
     it "creates an operation which adds given argument as Content-Type header" do
       conn = build_conn(default_env)
-      plug = described_class['text/html']
+      operation = described_class.('text/html')
 
-      new_conn = plug.(conn)
+      new_conn = operation.(conn)
 
       expect(new_conn.response_headers['Content-Type']).to eq('text/html')
     end


### PR DESCRIPTION
This follows the function abstraction for callable objects, as plugs are
just higher order functions which return another function (operation).

So, `.[]` method has been renamed to `.()` for the following plugs:

- WebPipe::Plugs::Config
- WebPipe::Plugs::ContentType
- WebPipe::Plugs::SanitizeParams