### PR TITLE
Changes to dry-schema extension

### DIFF
--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -10,11 +10,10 @@ module WebPipe
   #
   # On its own, the library just provides with a
   # `Conn#sanitized_params` method, which will return what is set into
-  # bag's `:sanitized_params` key.
+  # config's `:sanitized_params` key.
   #
-  # This key in the bag is what will be populated by `SanitizeParams`
-  # plug, which accepts a `dry-validation` schema that will be applied
-  # to `Conn#params`:
+  # This key in config is what will be populated by `SanitizeParams` plug, which
+  # accepts a `dry-schema` schema that will be applied to `Conn#params`:
   #
   # @example
   #  require 'web_pipe'
@@ -69,7 +68,7 @@ module WebPipe
     SANITIZED_PARAMS_KEY = :sanitized_params
 
     def sanitized_params
-      fetch(SANITIZED_PARAMS_KEY)
+      fetch_config(SANITIZED_PARAMS_KEY)
     end
   end
 

--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -12,8 +12,10 @@ module WebPipe
   # `Conn#sanitized_params` method, which will return what is set into
   # config's `:sanitized_params` key.
   #
-  # This key in config is what will be populated by `SanitizeParams` plug, which
-  # accepts a `dry-schema` schema that will be applied to `Conn#params`:
+  # This key in config is what will be populated by `SanitizeParams` plug. It
+  # takes as arguments the `dry-schema` schema that will be applied to
+  # `Conn#params` and an error handler taking `Conn` instance and the validation
+  # result:
   #
   # @example
   #  require 'web_pipe'
@@ -27,27 +29,19 @@ module WebPipe
   #      required(:name).filled(:string)
   #    end
   #
-  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams[Schema]
+  #    plug :sanitize_params, WebPipe::Plugs::SanitizeParams.(
+  #      Schema,
+  #      ->(conn, result) { ... }
+  #    )
   #    plug(:do_something_with_params) do |conn|
   #      DB.persist(:entity, conn.sanitized_params)
   #    end
   #  end
   #
-  # By default, when the result of applying the schema is a failure,
-  # {Conn} is halted with a 500 as status code. However, you can
-  # specify your own handler for the unhappy path. It will take the
-  # {Conn} and {Dry::Schema::Result} instances as arguments:
-  #
-  # @example
-  #   plug :sanitize_params, WebPipe::Plugs::SanitizeParams[
-  #                            Schema,
-  #                            ->(conn, result) { ... }
-  #                          ]
-  #
   # A common workflow is applying the same handler for all param
   # sanitization across your application. This can be achieved configuring
   # a `:param_sanitization_handler` in a upstream operation which can
-  # be composed downstream for any number of pipes. `SanitizeParams`
+  # be composed downstream from any number of pipes. `SanitizeParams`
   # will used configured handler if none is injected as
   # argument.
   #

--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -1,5 +1,7 @@
 require 'web_pipe'
 
+WebPipe.load_extensions(:params)
+
 module WebPipe
   # Integration with `dry-schema` validation library.
   #

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -30,7 +30,7 @@ module WebPipe
         lambda do |conn|
           result = schema.(conn.params)
           if result.success?
-            conn.add(DrySchema::SANITIZED_PARAMS_KEY, result.output)
+            conn.add_config(DrySchema::SANITIZED_PARAMS_KEY, result.output)
           else
             get_handler(conn, handler).(conn, result)
           end

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -12,16 +12,6 @@ module WebPipe
       # @return [Symbol]
       PARAM_SANITIZATION_HANDLER_KEY = :param_sanitization_handler
 
-      # Default handler if none is configured nor injected.
-      #
-      # @return [ParamSanitizationHandler::Handler[]]
-      DEFAULT_HANDLER = lambda do |conn, _result|
-        conn.
-          set_status(500).
-          set_response_body('Given params do not conform with the expected schema').
-          halt
-      end
-
       # @param schema [Dry::Schema::Processor]
       # @param handler [ParamSanitizationHandler::Handler[]]
       #
@@ -40,9 +30,7 @@ module WebPipe
       def self.get_handler(conn, handler)
         return handler unless handler == Types::Undefined
 
-        conn.fetch_config(
-          PARAM_SANITIZATION_HANDLER_KEY, DEFAULT_HANDLER
-        )
+        conn.fetch_config(PARAM_SANITIZATION_HANDLER_KEY)
       end
       private_class_method :get_handler
     end

--- a/spec/extensions/dry_schema/dry_schema_spec.rb
+++ b/spec/extensions/dry_schema/dry_schema_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe WebPipe::Conn do
   before { WebPipe.load_extensions(:dry_schema) }
 
   describe '#sanitized_params' do
-    it "returns bag's sanitized key" do
+    it "returns config's sanitized key" do
       conn = WebPipe::ConnSupport::Builder.(default_env)
       sanitized_params = {}.freeze
 
-      new_conn = conn.add(:sanitized_params, sanitized_params)
+      new_conn = conn.add_config(:sanitized_params, sanitized_params)
 
-      expect(new_conn.sanitized_params).to be(sanitized_params)
+      expect(new_conn.fetch_config(:sanitized_params)).to be(sanitized_params)
     end
   end
 end

--- a/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
+++ b/spec/extensions/dry_schema/plugs/sanitize_params_spec.rb
@@ -65,15 +65,6 @@ RSpec.describe WebPipe::Plugs::SanitizeParams do
         expect(new_conn).to be_halted
         expect(new_conn.response_body[0]).to eq('Something went wrong')
       end
-
-      it 'uses default handler if none is injected nor configured' do
-        conn = WebPipe::ConnSupport::Builder.(default_env)
-        operation = described_class.(schema)
-
-        new_conn = operation.(conn)
-
-        expect(new_conn.status).to be(500)
-      end
     end
   end
 end


### PR DESCRIPTION
- Automatically load `:params` extension.
- Store sanitized params in `Conn#config` instead of `Conn#bag`.
- Don't use a default handler: Force one to be defined.