### PR TITLE
Rename Rack module to RackSupport

### DIFF
--- a/lib/web_pipe/conn_support/builder.rb
+++ b/lib/web_pipe/conn_support/builder.rb
@@ -14,7 +14,7 @@ module WebPipe
       #
       # @return [Conn::Ongoing]
       def self.call(env)
-        rr = ::Rack::Request.new(env)
+        rr = Rack::Request.new(env)
         Conn::Ongoing.new(
           request: rr,
           env: env,

--- a/lib/web_pipe/conn_support/types.rb
+++ b/lib/web_pipe/conn_support/types.rb
@@ -11,7 +11,7 @@ module WebPipe
       include Dry.Types()
 
       Env = Strict::Hash
-      Request = Instance(::Rack::Request)
+      Request = Instance(Rack::Request)
 
       Scheme = Strict::Symbol.enum(:http, :https)
       Method = Strict::Symbol.enum(

--- a/lib/web_pipe/dsl/dsl_context.rb
+++ b/lib/web_pipe/dsl/dsl_context.rb
@@ -1,7 +1,7 @@
 require 'web_pipe'
 require 'web_pipe/types'
 require 'web_pipe/plug'
-require 'web_pipe/rack/middleware_specification'
+require 'web_pipe/rack_support/middleware_specification'
 
 module WebPipe
   module DSL
@@ -13,7 +13,7 @@ module WebPipe
     # @api private
     class DSLContext
       # @!attribute middleware_specifications
-      # @return [Array<Rack::MiddlewareSpecifications>]
+      # @return [Array<RackSupport::MiddlewareSpecifications>]
       attr_reader :middleware_specifications
 
       # @!attribute plugs
@@ -22,7 +22,7 @@ module WebPipe
 
       def initialize(middleware_specifications, plugs)
         @middleware_specifications = Types.Array(
-          Rack::MiddlewareSpecification
+          RackSupport::MiddlewareSpecification
         )[middleware_specifications]
         @plugs = Types.Array(Plug::Instance)[plugs]
       end
@@ -37,12 +37,12 @@ module WebPipe
       # - As a {WebPipe} class instance, in which case all its rack
       # middlewares will be considered.
       #
-      # @param name [Rack::MiddlewareSpecification::Name[]]
-      # @param spec [Rack::MiddlewareSpecification::Spec[]]
+      # @param name [RackSupport::MiddlewareSpecification::Name[]]
+      # @param spec [RackSupport::MiddlewareSpecification::Spec[]]
       #
-      # @return [Array<Rack::Middleware>]
+      # @return [Array<RackSupport::Middleware>]
       def use(name, *spec)
-        middleware_specifications << Rack::MiddlewareSpecification.new(name: name, spec: spec)
+        middleware_specifications << RackSupport::MiddlewareSpecification.new(name: name, spec: spec)
       end
 
       # Creates and adds a plug to the stack.

--- a/lib/web_pipe/dsl/instance_methods.rb
+++ b/lib/web_pipe/dsl/instance_methods.rb
@@ -2,8 +2,8 @@ require 'web_pipe/types'
 require 'web_pipe/conn'
 require 'web_pipe/app'
 require 'web_pipe/plug'
-require 'web_pipe/rack/app_with_middlewares'
-require 'web_pipe/rack/middleware_specification'
+require 'web_pipe/rack_support/app_with_middlewares'
+require 'web_pipe/rack_support/middleware_specification'
 require 'web_pipe/conn_support/composition'
 
 module WebPipe
@@ -29,7 +29,7 @@ module WebPipe
       # Type for how plugs and middlewares should be injected.
       Injections = Types::Strict::Hash.schema(
         plugs: Plug::Injections,
-        middlewares: Rack::MiddlewareSpecification::Injections
+        middlewares: RackSupport::MiddlewareSpecification::Injections
       )
 
       # @!attribute [r] injections [Injections[]]
@@ -37,26 +37,26 @@ module WebPipe
       # has been configured.
       attr_reader :injections
 
-      # @return [Rack::AppWithMiddlewares[]]
+      # @return [RackSupport::AppWithMiddlewares[]]
       attr_reader :rack_app
 
       # @return [ConnSupport::Composition::Operation[]]
       attr_reader :operations
 
-      # @return [Array<Rack::Middlewares>]
+      # @return [Array<RackSupport::Middlewares>]
       attr_reader :middlewares
 
       def initialize(injects = EMPTY_INJECTIONS)
         @injections = Injections[injects]
         container = self.class.container
-        @middlewares = Rack::MiddlewareSpecification.inject_and_resolve(
+        @middlewares = RackSupport::MiddlewareSpecification.inject_and_resolve(
           self.class.middleware_specifications, injections[:middlewares]
         )
         @operations = Plug.inject_and_resolve(
           self.class.plugs, injections[:plugs], container, self
         )
         app = App.new(operations)
-        @rack_app = Rack::AppWithMiddlewares.new(middlewares, app)
+        @rack_app = RackSupport::AppWithMiddlewares.new(middlewares, app)
       end
       
       # Expected interface for rack.

--- a/lib/web_pipe/extensions/cookies/cookies.rb
+++ b/lib/web_pipe/extensions/cookies/cookies.rb
@@ -60,7 +60,7 @@ module WebPipe
     # @param value [String]
     # @param opts [SET_COOKIE_OPTIONS[]]
     def set_cookie(key, value, opts = Types::EMPTY_HASH)
-      ::Rack::Utils.set_cookie_header!(
+      Rack::Utils.set_cookie_header!(
         response_headers,
         key,
         { value: value }.merge(SET_COOKIE_OPTIONS[opts])
@@ -71,7 +71,7 @@ module WebPipe
     # @param key [String]
     # @param opts [DELETE_COOKIE_OPTIONS[]]
     def delete_cookie(key, opts = Types::EMPTY_HASH)
-      ::Rack::Utils.delete_cookie_header!(
+      Rack::Utils.delete_cookie_header!(
         response_headers,
         key,
         DELETE_COOKIE_OPTIONS[opts]

--- a/lib/web_pipe/extensions/session/session.rb
+++ b/lib/web_pipe/extensions/session/session.rb
@@ -34,7 +34,7 @@ module WebPipe
     #
     # @return [Rack::Session::Abstract::SessionHash]
     def session
-      env.fetch(::Rack::RACK_SESSION) do
+      env.fetch(Rack::RACK_SESSION) do
         raise ConnSupport::MissingMiddlewareError.new(
                 'session', 'Rack::Session', 'https://www.rubydoc.info/github/rack/rack/Rack/Session'
               )

--- a/lib/web_pipe/rack_support/app_with_middlewares.rb
+++ b/lib/web_pipe/rack_support/app_with_middlewares.rb
@@ -1,9 +1,9 @@
 require 'web_pipe/types'
-require 'web_pipe/rack/middleware'
+require 'web_pipe/rack_support/middleware'
 require 'rack'
 
 module WebPipe
-  module Rack
+  module RackSupport
     # Helper to build and call a rack application with middlewares.
     #
     # @api private
@@ -43,7 +43,7 @@ module WebPipe
       private
 
       def build_rack_app(rack_middlewares, app)
-        ::Rack::Builder.new.tap do |b|
+        Rack::Builder.new.tap do |b|
           rack_middlewares.each do |middleware|
             b.use(middleware.middleware, *middleware.options)
           end

--- a/lib/web_pipe/rack_support/middleware.rb
+++ b/lib/web_pipe/rack_support/middleware.rb
@@ -2,7 +2,7 @@ require 'web_pipe/types'
 require 'dry/struct'
 
 module WebPipe
-  module Rack
+  module RackSupport
     # Simple data structure to represent a rack middleware class with
     # its initialization options.
     #

--- a/lib/web_pipe/rack_support/middleware_specification.rb
+++ b/lib/web_pipe/rack_support/middleware_specification.rb
@@ -1,9 +1,9 @@
 require 'dry/struct'
-require 'web_pipe/rack/middleware'
+require 'web_pipe/rack_support/middleware'
 require 'web_pipe/types'
 
 module WebPipe
-  module Rack
+  module RackSupport
     # Specification on how to resolve {Rack::Middleware}'s.
     #
     # Rack middlewares can be specified in two ways:
@@ -11,8 +11,8 @@ module WebPipe
     # - As an array where fist element is a rack middleware class
     # while the rest of elements are its initialization options.
     # - A single element array where it is an instance of a class
-    # including {WebPipe}. This specifies all {Rack::Middlewares}
-    # for that {WebPipe}.
+    # including {WebPipe}. This specifies all {RackSupport::Middlewares} for
+    # that {WebPipe}.
     #
     # @api private
     class MiddlewareSpecification < Dry::Struct
@@ -26,7 +26,7 @@ module WebPipe
       #
       # @see #inject_and_resolve
       Injections = Types::Strict::Hash.map(
-        Rack::MiddlewareSpecification::Name, Rack::MiddlewareSpecification::Spec
+        RackSupport::MiddlewareSpecification::Name, RackSupport::MiddlewareSpecification::Spec
       ).default(Types::EMPTY_HASH)
 
       # @!attribute [r] name
@@ -42,7 +42,7 @@ module WebPipe
       # @param middleware_specifications [Array<MiddlewareSpecification>]
       # @param injections [Injections[]]
       #
-      # @return [Array<Rack::Middleware>]
+      # @return [Array<RackSupport::Middleware>]
       def self.inject_and_resolve(middleware_specifications, injections)
         middleware_specifications.map do |spec|
           if injections.has_key?(spec.name)
@@ -53,9 +53,9 @@ module WebPipe
         end.flatten
       end
 
-      # Resolves {Rack::Middlewares} from given specification.
+      # Resolves {RackSupport::Middlewares} from given specification.
       #
-      # @return [Array<Rack::Middleware>]
+      # @return [Array<RackSupport::Middleware>]
       def call
         klass = spec[0]
         options = spec[1..-1] || Types::EMPTY_ARRAY

--- a/spec/unit/web_pipe/rack/middleware_specification_spec.rb
+++ b/spec/unit/web_pipe/rack/middleware_specification_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'web_pipe'
-require 'web_pipe/rack/middleware'
-require 'web_pipe/rack/middleware_specification'
+require 'web_pipe/rack_support/middleware'
+require 'web_pipe/rack_support/middleware_specification'
 require 'support/middlewares'
 
-RSpec.describe WebPipe::Rack::MiddlewareSpecification do
+RSpec.describe WebPipe::RackSupport::MiddlewareSpecification do
   let(:pipe) do
     Class.new do
       include WebPipe
@@ -21,17 +21,17 @@ RSpec.describe WebPipe::Rack::MiddlewareSpecification do
     end
 
     context 'when spec is a class' do
-      it "returns it as a WebPipe::Rack::Middleware with empty options" do
+      it "returns it as a WebPipe::RackSupport::Middleware with empty options" do
         expect(described_class.new(name: :name, spec: [FirstNameMiddleware]).call).to eq(
-          [WebPipe::Rack::Middleware.new(middleware: FirstNameMiddleware, options: [])]
+          [WebPipe::RackSupport::Middleware.new(middleware: FirstNameMiddleware, options: [])]
         )
       end
     end
 
     context 'when spec is a class with options' do
-      it "returns it as a WebPipe::Rack::Middleware with given options" do
+      it "returns it as a WebPipe::RackSupport::Middleware with given options" do
         expect(described_class.new(name: :name, spec: [LastNameMiddleware, name: 'Joe']).call).to eq(
-          [WebPipe::Rack::Middleware.new(middleware: LastNameMiddleware, options: [name: 'Joe'])]
+          [WebPipe::RackSupport::Middleware.new(middleware: LastNameMiddleware, options: [name: 'Joe'])]
         )
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe WebPipe::Rack::MiddlewareSpecification do
         middleware_specifications, injections
       )
 
-      rack_middleware = WebPipe::Rack::Middleware.new(middleware: FirstNameMiddleware, options: [])
+      rack_middleware = WebPipe::RackSupport::Middleware.new(middleware: FirstNameMiddleware, options: [])
       expect(result.freeze).to eq([rack_middleware]*2.freeze)
     end
   end


### PR DESCRIPTION
Otherwise including `WebPipe` module made necessary to reference rack
namespace as `::Rack`