### PR TITLE
Extension integrating with Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ In order to use in conjunction with [dry-rb](https://dry-rb.org/)
 ecosystem, see also
 [`dry-web-web_pipe`](https://github.com/waiting-for-dev/dry-web-web_pipe).
 
+If you want to use it with a Rails project, don't miss docs for the [rails
+extension](docs/extensions/rails.md).
+
 1. [Introduction](docs/introduction.md)
 1. [Design model](docs/design_model.md)
 1. [Building a rack application](docs/building_a_rack_application.md)
@@ -36,6 +39,7 @@ ecosystem, see also
    1. [Dry Schema](docs/extensions/dry_schema.md)
    1. [Dry View](docs/extensions/dry_view.md)
    1. [Params](docs/extensions/params.md)
+   1. [Rails](docs/extensions/rails.md)
    1. [Redirect](docs/extensions/redirect.md)
    1. [Router params](docs/extensions/router_params.md)
    1. [Session](docs/extensions/session.md)

--- a/docs/extensions/rails.md
+++ b/docs/extensions/rails.md
@@ -1,0 +1,115 @@
+# Rails
+
+The first two things to keep in mind in order to integrate with Rails is
+that `WebPipe` instances are Rack applications and that rails router can
+perfectly [dispatch to a rack application](https://guides.rubyonrails.org/routing.html#routing-to-rack-applications). For example:
+
+```ruby
+# config/routes.rb
+get '/my_route', to: MyRoute.new
+
+# app/controllers/my_route.rb
+class MyRoute
+  include WebPipe
+
+  plug :set_response_body
+
+  private
+
+  def set_response_body(conn)
+    conn.set_response_body('Hello, World!')
+  end
+end
+```
+
+In order to do something like the previous example you don't need to enable
+this extension. Notice that rails took care of dispatching the request to our
+`WebPipe` rack application, which was then responsible for generating the
+response. In this case, it used a simple call to `#set_response_body`.
+
+It's quite possible that you don't need more than that in terms of rails
+integration. Of course, surely you want something more elaborate to generate
+responses. For that, you can use the view or template system you like. One
+option that will play specially well here is
+[`dry-view`](https://dry-rb.org/gems/dry-view/), which
+[integrates](https://github.com/dry-rb/dry-view/tree/master/examples/rails)
+itself easily with Rails. Furthermore, we have a tailored `dry_view`
+[extension](https://waiting-for-dev.github.io/web_pipe/docs/extensions/dry_view.html).
+
+You need to use this extension if:
+
+- You want to use `action_view` as rendering system.
+- You want to use rails url helpers from your `WebPipe` application.
+- You want to use controller helpers from your `WebPipe` application.
+
+Rails responsibilities for controlling the request/response cycle and the
+rendering process are a little bit tangled. For this reason, even if you
+want to use `WebPipe` applications instead of Rails controller actions you
+still have to use the typical top `ApplicationController` in order to define
+some behaviour for the view layer:
+
+- Which layout is applied to the template.
+- Which helpers will become available to the templates.
+- Where within `app/views/` templates are looked up.
+
+By default, the controller in use is `ActionController::Base`, which means that
+no layout is applied and only built-in helpers (for example,
+`number_as_currency`) are available. You can change it via the
+`:rails_controller` configuration option.
+
+The main method that this extension adds to `WebPipe::Conn` is `#render`,
+which just delegates to the [Rails
+implementation](https://api.rubyonrails.org/v6.0.1/classes/ActionController/Renderer.html)
+as you'd do in a typical rails controller. Remember that you can provide
+template instance variables through the keyword `:assigns`.
+
+```ruby
+# config/routes.rb
+get '/articles', to: ArticlesIndex.new
+
+# app/controllers/application_controller.rb
+class ApplicationController < ActionController::Base
+  # By default uses the layout in `layouts/application`
+end
+
+# app/controllers/articles_index.rb
+require 'web_pipe/plugs/config'
+
+WebPipe.load_extensions(:rails) # You can put it in an initializer
+
+class ArticlesIndex
+  include WebPipe
+
+  plug :config, WebPipe::Plugs::Config.(
+    rails_controller: ApplicationController
+  )
+
+  def render(conn)
+    conn.render(
+      template: 'articles/index',
+      assigns: { articles: Article.all }
+    )
+  end
+end
+```
+
+Notice that we used the keyword `template:` instead of taking advantage of
+automatic template lookup. We did that way so that we don't have to create also
+an `ArticlesController`, but it's up to you.
+
+Besides, this extension provides with two other methods:
+
+- `url_helpers` returns Rails router [url
+  helpers](https://api.rubyonrails.org/v6.0.1/classes/ActionView/Helpers/UrlHelper.html).
+- `helpers` returns the associated [controller
+  helpers](https://api.rubyonrails.org/classes/ActionController/Helpers.html).
+
+In all the examples we have supposed that we are putting `WebPipe` applications
+within `app/controllers/` directory. However, remember you can put them
+wherever you like as long as you respect rails [`autoload_paths`](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-paths).
+
+Here you have a link to a very simple and contrived example of a rails
+application integrating `web_pipe`:
+
+https://github.com/waiting-for-dev/rails-web_pipe
+

--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -51,6 +51,10 @@ module WebPipe
     require 'web_pipe/extensions/params/params'
   end
 
+  register_extension :rails do
+    require 'web_pipe/extensions/rails/rails'
+  end
+
   register_extension :session do
     require 'web_pipe/extensions/session/session'
   end

--- a/lib/web_pipe/extensions/rails/rails.rb
+++ b/lib/web_pipe/extensions/rails/rails.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'web_pipe/conn'
+
+module WebPipe
+  # Integrates with Rails framework.
+  #
+  # The first two things to keep in mind in order to integrate with Rails is
+  # that {WebPipe} instances are Rack applications and that rails router can
+  # perfectly dispatch to a rack application. For example:
+  #
+  # ```ruby
+  # # config/routes.rb
+  # get '/my_route', to: MyRoute.new
+  #
+  # # app/controllers/my_route.rb
+  # class MyRoute
+  #   include WebPipe
+  #
+  #   plug :set_response_body
+  #
+  #   private
+  #
+  #   def set_response_body(conn)
+  #     conn.set_response_body('Hello, World!')
+  #   end
+  # end
+  # ```
+  #
+  # In order to do something like the previous example you don't need to enable
+  # this extension. Notice that rails took care of dispatching the request to
+  # our {WebPipe} rack application, which was then responsible for generating the
+  # response. In this case, it used a simple call to
+  # {WebPipe::Conn#set_response_body}.
+  #
+  # It's quite possible that you don't need more than that in terms of rails
+  # integration. Of course, surely you want something more elaborate to generate
+  # responses. For that, you can use the view or template system you like. One
+  # option that will play specially well here is `dry-view`, which integrates
+  # itself easily with Rails. Furthermore, we have a tailored `dry_view`
+  # extension.
+  #
+  # You need to use this extension if:
+  #
+  # - You want to use `action_view` as rendering system.
+  # - You want to use rails url helpers from your {WebPipe} application.
+  # - You want to use controller helpers from your {WebPipe} application.
+  #
+  # Rails responsibilities for controlling the request/response cycle and the
+  # rendering process are a little bit tangled. For this reason, even if you
+  # want to use {WebPipe} applications instead of Rails controller actions you
+  # still have to use the typical top `ApplicationController` in order to define
+  # some behaviour for the view layer:
+  #
+  # - Which layout is applied to the template.
+  # - Which helpers will become available to the templates.
+  # - Where within `app/views/` templates are looked up.
+  #
+  # By default, the controller in use is `ActionController::Base`, which means
+  # that no layout is applied and only built-in helpers (for example,
+  # `number_as_currency`) are available. You can change it via the
+  # `:rails_controller` configuration option.
+  #
+  # The main method that this extension adds to {WebPipe::Conn} is `#render`,
+  # which just delegates to the Rails implementation as you'd do in a typical
+  # rails controller. Remember that you can provide template instance variables
+  # through the keyword `:assigns`.
+  #
+  # ```ruby
+  # # config/routes.rb
+  # get '/articles', to: ArticlesIndex.new
+  #
+  # # app/controllers/application_controller.rb
+  # class ApplicationController < ActionController::Base
+  #   # By default uses the layout in `layouts/application`
+  # end
+  # 
+  # # app/controllers/articles_index.rb
+  # require 'web_pipe/plugs/config'
+  #
+  #
+  # WebPipe.load_extensions(:rails) # You can put it in an initializer
+  #
+  # class ArticlesIndex
+  #   include WebPipe
+  #
+  #   plug :config, WebPipe::Plugs::Config.(
+  #     rails_controller: ApplicationController
+  #   )
+  #
+  #   def render(conn)
+  #     conn.render(
+  #       template: 'articles/index',
+  #       assigns: { articles: Article.all }
+  #     )
+  #   end
+  # end
+  # ```
+  #
+  # Notice that we used the keyword `template:` instead of taking advantage of
+  # automatic template lookup. We did that way so that we don't have to create
+  # also an `ArticlesController`, but it's up to you.
+  #
+  # Besides, this extension provides with two other methods:
+  #
+  # - `url_helpers` returns Rails router url helpers.
+  # - `helpers` returns the associated controller helpers.
+  #
+  # In all the examples we have supposed that we are putting {WebPipe}
+  # applications within `app/controllers/` directory. However, remember you can
+  # put them wherever you like as long as you respect rails `autoload_paths`.
+  #
+  # Here you have a link to a very simple and contrived example of a rails
+  # application integrating `web_pipe`:
+  #
+  # https://github.com/waiting-for-dev/rails-web_pipe
+  #
+  # @see https://guides.rubyonrails.org/routing.html#routing-to-rack-applications
+  # @see https://dry-rb.org/gems/dry-view/
+  # @see https://github.com/dry-rb/dry-view/tree/master/examples/rails
+  # @see https://waiting-for-dev.github.io/web_pipe/docs/extensions/dry_view.html
+  # @see https://api.rubyonrails.org/v6.0.1/classes/ActionController/Renderer.html
+  # @see https://api.rubyonrails.org/v6.0.1/classes/ActionController/Renderer.html
+  # @see https://api.rubyonrails.org/v6.0.1/classes/ActionView/Helpers/UrlHelper.html
+  # @see https://api.rubyonrails.org/classes/ActionController/Helpers.html
+  # @see https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-paths
+  module Rails
+    def render(*args)
+      set_response_body(
+        rails_controller.renderer.render(*args)
+      )
+    end
+
+    # @see https://devdocs.io/rails~6.0/actioncontroller/helpers
+    def helpers
+      rails_controller.helpers
+    end
+
+    # @see https://api.rubyonrails.org/v6.0.1/classes/ActionView/Helpers/UrlHelper.html
+    def url_helpers
+      ::Rails.application.routes.url_helpers
+    end
+
+    private
+
+    def rails_controller
+      config.fetch(:rails_controller, ActionController::Base)
+    end
+  end
+
+  Conn.include(Rails)
+end

--- a/spec/extensions/rails/rails_spec.rb
+++ b/spec/extensions/rails/rails_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/conn'
+require 'web_pipe/conn'
+
+RSpec.describe WebPipe::Conn do
+  before do
+    WebPipe.load_extensions(:rails)
+  end
+
+  before(:all) do
+    module ActionController
+      module Base
+        def self.renderer
+          Renderer.new
+        end
+
+        def self.helpers
+          {
+            helper1: 'foo'
+          }
+        end
+      end
+
+      class Renderer
+        def render(*args)
+          action = args[0]
+          case action
+          when 'show'
+            'Show'
+          else
+            'Not found'
+          end
+        end
+      end
+    end
+  end
+
+  after(:all) { Object.send(:remove_const, :ActionController) }
+
+  describe '#render' do
+    it 'sets rendered as response body' do
+      conn = build_conn(default_env)
+
+      new_conn = conn.render('show')
+
+      expect(new_conn.response_body).to eq(['Show'])
+    end
+
+    it 'uses configured controller' do
+      module MyController
+        def self.renderer
+          Renderer.new
+        end
+
+        class Renderer
+          def render(*args)
+            'Rendered from MyController'
+          end
+        end
+      end
+      conn = build_conn(default_env)
+
+      new_conn = conn
+        .add_config(:rails_controller, MyController)
+        .render(:whatever)
+
+      expect(new_conn.response_body).to eq(['Rendered from MyController'])
+
+      Object.send(:remove_const, :MyController)
+    end
+  end
+
+  describe '#helpers' do
+    it 'returns controller helpers' do
+      conn = build_conn(default_env)
+
+      expect(conn.helpers).to eq(helper1: 'foo')
+    end
+
+    it 'uses configured controller' do
+      module MyController
+        def self.helpers
+          { helper1: 'bar' }
+        end
+      end
+      conn = build_conn(default_env)
+
+      new_conn = conn.add_config(:rails_controller, MyController)
+
+      expect(new_conn.helpers).to eq(helper1: 'bar')
+
+      Object.send(:remove_const, :MyController)
+    end
+  end
+end


### PR DESCRIPTION
The first two things to keep in mind in order to integrate with Rails is
that `WebPipe` instances are Rack applications and that rails router can
perfectly [dispatch to a rack application](https://guides.rubyonrails.org/routing.html#routing-to-rack-applications). For example:

```ruby
 # config/routes.rb
get '/my_route', to: MyRoute.new

 # app/controllers/my_route.rb
class MyRoute
  include WebPipe

  plug :set_response_body

  private

  def set_response_body(conn)
    conn.set_response_body('Hello, World!')
  end
end
```

In order to do something like the previous example you don't need to enable
this extension. Notice that rails took care of dispatching the request to our
`WebPipe` rack application, which was then responsible for generating the
response. In this case, it used a simple call to `#set_response_body`.

It's quite possible that you don't need more than that in terms of rails
integration. Of course, surely you want something more elaborate to generate
responses. For that, you can use the view or template system you like. One
option that will play specially well here is [`dry-view`](https://dry-rb.org/gems/dry-view/), which
[integrates](https://github.com/dry-rb/dry-view/tree/master/examples/rails)
itself easily with Rails. Furthermore, we have a tailored `dry_view` [extension](https://waiting-for-dev.github.io/web_pipe/docs/extensions/dry_view.html).

You need to use this extension if:

- You want to use `action_view` as rendering system.
- You want to use rails url helpers from your `WebPipe` application.
- You want to use controller helpers from your `WebPipe` application.

Rails responsibilities for controlling the request/response cycle and the
rendering process are a little bit tangled. For this reason, even if you
want to use `WebPipe` applications instead of Rails controller actions you
still have to use the typical top `ApplicationController` in order to define
some behaviour for the view layer:

- Which layout is applied to the template.
- Which helpers will become available to the templates.
- Where within `app/views/` templates are looked up.

By default, the controller in use is `ActionController::Base`, which means that
no layout is applied and only built-in helpers (for example,
`number_as_currency`) are available. You can change it via the
`:rails_controller` configuration option.

The main method that this extension adds to `WebPipe::Conn` is `#render`,
which just delegates to the [Rails
implementation](https://api.rubyonrails.org/v6.0.1/classes/ActionController/Renderer.html)
as you'd do in a typical rails controller. Remember that you can provide
template instance variables through the keyword `:assigns`.

```ruby
 # config/routes.rb
get '/articles', to: ArticlesIndex.new

 # app/controllers/application_controller.rb
class ApplicationController < ActionController::Base
  # By default uses the layout in `layouts/application`
end

 # app/controllers/articles_index.rb
require 'web_pipe/plugs/config'

WebPipe.load_extensions(:rails) # You can put it in an initializer

class ArticlesIndex
  include WebPipe

  plug :config, WebPipe::Plugs::Config.(
    rails_controller: ApplicationController
  )

  def render(conn)
    conn.render(
      template: 'articles/index',
      assigns: { articles: Article.all }
    )
  end
end
```

Notice that we used the keyword `template:` instead of taking advantage of
automatic template lookup. We did that way so that we don't have to create also
an `ArticlesController`, but it's up to you.

Besides, this extension provides with two other methods:

- `url_helpers` returns Rails router [url
  helpers](https://api.rubyonrails.org/v6.0.1/classes/ActionView/Helpers/UrlHelper.html).
- `helpers` returns the associated [controller
  helpers](https://api.rubyonrails.org/classes/ActionController/Helpers.html).

In all the examples we have supposed that we are putting `WebPipe` applications
within `app/controllers/` directory. However, remember you can put them
wherever you like as long as you respect rails [`autoload_paths`](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-paths).

Here you have a link to a very simple and contrived example of a rails
application integrating `web_pipe`:

https://github.com/waiting-for-dev/rails-web_pipe