### PR TITLE
Switch transproc to dry-transformer

### DIFF
--- a/lib/web_pipe/extensions/params/params.rb
+++ b/lib/web_pipe/extensions/params/params.rb
@@ -14,9 +14,9 @@ module WebPipe
   #   # http://www.example.com?foo=bar
   #   conn.params #=> { 'foo' => 'bar' }
   #
-  # Further processing can be specified thanks to `transproc` gem (you
+  # Further processing can be specified thanks to `dry-transformer` gem (you
   # need to add it yourself to the Gemfile). All hash transformations
-  # in `transproc` are available:
+  # in `dry-transformer` are available:
   #
   # @example
   #   # http://www.example.com?foo=bar
@@ -65,7 +65,7 @@ module WebPipe
   #   conn.
   #     params(fake) #=> { fake: :params }
   #
-  # @see https://github.com/solnic/transproc
+  # @see https://github.com/dry-rb/dry-transformer
   module Params
     # Key where configured transformations are set
     PARAM_TRANSFORMATION_KEY = :param_transformations

--- a/lib/web_pipe/extensions/params/params/transf.rb
+++ b/lib/web_pipe/extensions/params/params/transf.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'transproc'
+require 'dry/transformer'
 
 module WebPipe
   module Params
     module Transf
-      extend Transproc::Registry
+      extend Dry::Transformer::Registry
 
-      import Transproc::HashTransformations
+      import Dry::Transformer::HashTransformations
 
       def self.id(params)
         params

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -39,10 +39,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-struct', '~> 1.0'
   spec.add_runtime_dependency 'dry-types', '~> 1.1'
   spec.add_runtime_dependency 'rack', '~> 2.0'
-  spec.add_runtime_dependency 'dry-transformer', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'dry-schema', '~> 1.0'
+  spec.add_development_dependency 'dry-transformer', '~> 0.1'
   spec.add_development_dependency 'dry-view', '~> 0.7'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack-flash3', '~> 1.0'

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-struct', '~> 1.0'
   spec.add_runtime_dependency 'dry-types', '~> 1.1'
   spec.add_runtime_dependency 'rack', '~> 2.0'
-  spec.add_runtime_dependency 'transproc', '~> 1.1'
+  spec.add_runtime_dependency 'dry-transformer', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'dry-schema', '~> 1.0'


### PR DESCRIPTION
It also makes optional `dry-transformer` dependency as it is only used by `params` extension