### PR TITLE
Allow inspecting middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ extension](docs/extensions/rails.md).
 1. [Using rack middlewares](docs/using_rack_middlewares.md)
    1. [Injecting middlewares](docs/using_rack_middlewares/injecting_middlewares.md)
    1. [Composing middlewares](docs/using_rack_middlewares/composing_middlewares.md)
+   1. [Inspecting middlewares](docs/using_rack_middlewares/inspecting_middlewares.md)
 1. [Composing applications](docs/composing_applications.md)
 1. [Connection struct](docs/connection_struct.md)
    1. [Sharing data downstream](docs/connection_struct/sharing_data_downstream.md)

--- a/docs/using_rack_middlewares/inspecting_middlewares.md
+++ b/docs/using_rack_middlewares/inspecting_middlewares.md
@@ -1,0 +1,34 @@
+# Inspecting middlewares
+
+Once a `WebPipe` class is initialized all its middlewares get resolved. They
+can be accessed through the `#middlewares` method.
+
+Each middleware is represented by a
+`WebPipe::RackSupport::MiddlewareSpecification` instance, which contains two
+accessors: `middleware` returns the middleware class, while `options` returns
+an array with the arguments that are provided to the middleware on initialization.
+
+Kepp in mind that every middleware is resolved as an array. This is because it
+can in fact be composed by an chain of middlewares built through
+[composition](composing_middlewares.md).
+
+
+```ruby
+require 'web_pipe'
+require 'rack/session'
+
+class MyApp
+  include WebPipe
+  
+  use :session, Rack::Session::Cookie, key: 'my_app.session', secret: 'long'
+
+  plug(:hello) do |conn|
+    conn.set_response_body('Hello world!')
+  end
+end
+
+app = MyApp.new
+session_middleware = app.middlewares[:session][0]
+session_middleware.middleware # => Rack::Session::Cookie
+session_middleware.options # => [{ key: 'my_app.session', secret: 'long' }]
+```

--- a/lib/web_pipe/dsl/instance_methods.rb
+++ b/lib/web_pipe/dsl/instance_methods.rb
@@ -42,10 +42,10 @@ module WebPipe
       # @return [RackSupport::AppWithMiddlewares[]]
       attr_reader :rack_app
 
-      # @return [Hash<WebPipe::Plug::Name[], ConnSupport::Composition::Operation[]>]
+      # @return [Hash<Plug::Name[], ConnSupport::Composition::Operation[]>]
       attr_reader :operations
 
-      # @return [Array<RackSupport::Middlewares>]
+      # @return [Hash<RackSupport::MiddlewareSpecification::Name[], Array<RackSupport::Middlewares>]
       attr_reader :middlewares
 
       # rubocop:disable Metrics/AbcSize
@@ -59,7 +59,7 @@ module WebPipe
           self.class.plugs, injections[:plugs], container, self
         )
         app = App.new(operations.values)
-        @rack_app = RackSupport::AppWithMiddlewares.new(middlewares, app)
+        @rack_app = RackSupport::AppWithMiddlewares.new(middlewares.values.flatten, app)
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/spec/integration/inspecting_middlewares_spec.rb
+++ b/spec/integration/inspecting_middlewares_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/conn'
+require 'support/middlewares'
+
+RSpec.describe 'Inspecting middlewares' do
+  let(:pipe_class) do
+    Class.new do
+      include WebPipe
+
+      use :first_name, FirstNameMiddleware
+
+      plug :hello do |conn|
+        conn.set_response_body('Hello')
+      end
+    end
+  end
+
+  it 'can inspect resolved middlewares' do
+    pipe = pipe_class.new
+
+    expect(pipe.middlewares[:first_name][0].middleware).to be(FirstNameMiddleware)
+  end
+
+  it 'can inspect injected middlewares' do
+    last_name = [LastNameMiddleware, { name: 'Smith' }]
+    pipe = pipe_class.new(middlewares: { first_name: last_name })
+
+    expect(pipe.middlewares[:first_name][0].middleware).to be(LastNameMiddleware)
+  end
+end

--- a/spec/unit/web_pipe/rack/middleware_specification_spec.rb
+++ b/spec/unit/web_pipe/rack/middleware_specification_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe WebPipe::RackSupport::MiddlewareSpecification do
   describe '#call' do
     context 'when spec is a WebPipe class' do
       it "returns an array with its WebPipe::Rack::Middleware's" do
-        expect(described_class.new(name: :name, spec: [pipe.new]).call).to include(*pipe.new.middlewares)
+        expect(described_class.new(name: :name, spec: [pipe.new]).call).to include(*pipe.new.middlewares.values)
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe WebPipe::RackSupport::MiddlewareSpecification do
   end
 
   describe '.inject_and_resolve' do
-    it 'inject specs and resolves resulting list of middlewares' do
+    it 'inject specs and resolves middlewares' do
       middleware_specifications = [
         described_class.new(name: :middleware1, spec: [FirstNameMiddleware]),
         described_class.new(name: :middleware2, spec: [pipe.new])
@@ -72,7 +72,7 @@ RSpec.describe WebPipe::RackSupport::MiddlewareSpecification do
       )
 
       rack_middleware = WebPipe::RackSupport::Middleware.new(middleware: FirstNameMiddleware, options: [])
-      expect(result.freeze).to eq([rack_middleware] * 2)
+      expect(result).to eq(middleware1: [rack_middleware], middleware2: [rack_middleware])
     end
   end
 end


### PR DESCRIPTION
In the same way that 8b3e90b42 did with operations, this commit adds the
option to inspect middlewares once a `WebPipe` app has been initialized.

Middlewares are returned as
`WebPipe::RackSupport::MiddlewareSpecification` instances. They are
returned as an array, as they in fact can be a chain of middlewares
built through middleware composition.

```ruby
require 'web_pipe'
require 'rack/session'

class MyApp
  include WebPipe

  use :session, Rack::Session::Cookie, key: 'my_app.session', secret: 'long'

  plug(:hello) do |conn|
    conn.set_response_body('Hello world!')
  end
end

app = MyApp.new
session_middleware = app.middlewares[:session][0]
session_middleware.middleware # => Rack::Session::Cookie
session_middleware.options # => [{ key: 'my_app.session', secret: 'long' }]
```