### PR TITLE
Introduce testing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ extension](docs/extensions/rails.md).
 1. [Plugs](docs/plugs.md)
    1. [Config](docs/plugs/config.md)
    1. [ContentType](docs/plugs/content_type.md)
+1. [Testing](docs/testing.md)
 1. [Extensions](docs/extensions.md)
    1. [Container](docs/extensions/container.md)
    1. [Cookies](docs/extensions/cookies.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,64 @@
+# Testing
+
+## Testing the rack application
+
+A `WebPipe` instance is a just a rack application, so you can test it as such:
+
+```ruby
+require 'web_pipe'
+require 'rack/mock'
+require 'rspec'
+
+class MyApp
+  include WebPipe
+
+  plug :response
+
+  private
+
+  def response(conn)
+    conn
+      .set_response_body('Hello!')
+      .set_status(200)
+  end
+end
+
+RSpec.describe MyApp do
+  it 'responds with 200 status code' do
+    env = Rack::MockRequest.env_for
+
+    status, _headers, _body = described_class.new.call(env)
+
+    expect(status).to be(200)
+  end
+end
+```
+
+## Testing individual operations
+
+Each operation in a pipe is an isolated function that takes a connection struct
+as argument. You can leverage [the inspection of
+operations](docs/plugging_operations/inspecting_operations.md) to unit test them.
+
+There's also a `WebPipe::TestSupport` module that you can include to get a
+helper method `#build_conn` to easily create a connection struct.
+
+```ruby
+RSpec.describe MyApp do
+  include WebPipe::TestSupport
+
+  describe '#response' do
+    it 'responds with 200 status code' do
+      conn = build_conn
+      operation = described_class.new.operations[:response]
+
+      new_conn = operation.call(conn)
+
+      expect(new_conn.status).to be(200)
+    end
+  end
+end
+```
+
+Check the API documentation for the options you can provide to
+[`#build_conn`](https://www.rubydoc.info/github/waiting-for-dev/web_pipe/master/WebPipe/TestSupport#build_conn).

--- a/lib/web_pipe/test_support.rb
+++ b/lib/web_pipe/test_support.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'web_pipe/conn_support/builder'
+require 'rack/mock'
+
+module WebPipe
+  # Test helper methods.
+  #
+  # This module is meant to be included in a test file to provide helper
+  # methods.
+  module TestSupport
+    # Builds a {WebPipe::Conn}
+    #
+    # @param uri [String] URI that will be used to populate the request
+    # attributes
+    # @param attributes [Hash<Symbol, Any>] Manually set attributes for the
+    # struct. It overrides what is taken from the `uri` parameter
+    # @param env_opts [Hash] Options to be added to the `env` from which the
+    # connection struct is created. See {Rack::MockRequest.env_for}.
+    # @return [Conn]
+    def build_conn(uri = '', attributes: {}, env_opts: {})
+      env = Rack::MockRequest.env_for(uri, env_opts)
+      ConnSupport::Builder
+        .call(env)
+        .new(attributes)
+    end
+  end
+end

--- a/spec/unit/web_pipe/test_support_spec.rb
+++ b/spec/unit/web_pipe/test_support_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'web_pipe/test_support'
+
+RSpec.describe WebPipe::TestSupport do
+  let(:klass) do
+    Class.new { include WebPipe::TestSupport }.new
+  end
+
+  describe '#build_conn' do
+    it 'returns a WebPipe::Conn::Ongoing instance' do
+      expect(
+        klass.build_conn.instance_of?(WebPipe::Conn::Ongoing)
+      ).to be(true)
+    end
+
+    it 'can shortcut through uri' do
+      conn = klass.build_conn('http://dummy.org?foo=bar')
+
+      expect(conn.host).to eq('dummy.org')
+      expect(conn.query_string).to eq('foo=bar')
+    end
+
+    it 'can override attributes' do
+      conn = klass.build_conn(attributes: { host: 'foo.bar' })
+
+      expect(conn.host).to eq('foo.bar')
+    end
+
+    it 'gives preference to the attributes over the uri' do
+      conn = klass.build_conn('http://joe.doe', attributes: { host: 'foo.bar' })
+
+      expect(conn.host).to eq('foo.bar')
+    end
+
+    it 'can forward env options' do
+      conn = klass.build_conn(env_opts: { method: 'PUT' })
+
+      expect(conn.request_method).to be(:put)
+    end
+  end
+end


### PR DESCRIPTION
This commit both adds documentation on how to test a `WebPipe` class,
and a module with a helper method that allows to easily create a
`WebPipe::Conn`:

```ruby
include WebPipe::TestSupport

conn = build_conn('http://example.com')
conn.schema # => 'http'
conn.host # => 'example.com'
```