### PR TITLE
Add not_found extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ extension](docs/extensions/rails.md).
    1. [Flash](docs/extensions/flash.md)
    1. [Dry Schema](docs/extensions/dry_schema.md)
    1. [Hanami View](docs/extensions/hanami_view.md)
+   1. [Not found](docs/extensions/not_found.md)
    1. [Params](docs/extensions/params.md)
    1. [Rails](docs/extensions/rails.md)
    1. [Redirect](docs/extensions/redirect.md)

--- a/docs/extensions/not_found.md
+++ b/docs/extensions/not_found.md
@@ -1,0 +1,40 @@
+# Not found
+
+This extension helps to build a not-found response in a single method
+invocation. The `WebPipe::Conn#not_found` method will:
+
+- Set 404 as response status.
+- Set 'Not found' as the response body, or instead run a step configured in
+`:not_found_body_step` config key.
+- Halt the connection struct.
+
+```ruby
+require 'web_pipe'
+require 'web_pipe/plugs/config'
+
+WebPipe.load_extensions(:params, :not_found)
+
+class ShowItem
+  include 'web_pipe'
+
+  plug :config, WebPipe::Plugs::Config.(
+    not_found_body_step: ->(conn) { conn.set_response_body('Nothing') }
+  )
+
+  plug :fetch_item do |conn|
+    conn.add(:item, Item[params['id']])
+  end
+
+  plug :check_item do |conn|
+    if conn.fetch(:item)
+      conn
+    else
+      conn.not_found
+    end
+  end
+
+  plug :render do |conn|
+    conn.set_response_body(conn.fetch(:item).name)
+  end
+end
+```

--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -62,4 +62,8 @@ module WebPipe
   register_extension :url do
     require 'web_pipe/extensions/url/url'
   end
+
+  register_extension :not_found do
+    require 'web_pipe/extensions/not_found/not_found'
+  end
 end

--- a/lib/web_pipe/extensions/not_found/not_found.rb
+++ b/lib/web_pipe/extensions/not_found/not_found.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#:nodoc:
+module WebPipe
+  # Generates a not-found response
+  #
+  # This extension helps to build a not-found response in a single method
+  # invocation. The {#not_found} method will:
+  #
+  # - Set 404 as response status.
+  # - Set 'Not found' as the response body, or instead run a step configured in
+  # a `:not_found_body_step` config key.
+  # - Halt the connection struct.
+  #
+  # @example
+  #   require 'web_pipe'
+  #   require 'web_pipe/plugs/config'
+  #
+  #   WebPipe.load_extensions(:params, :not_found)
+  #
+  #   class ShowItem
+  #     include 'web_pipe'
+  #
+  #     plug :config, WebPipe::Plugs::Config.(
+  #       not_found_body_step: ->(conn) { conn.set_response_body('Nothing') }
+  #     )
+  #
+  #     plug :fetch_item do |conn|
+  #       conn.add(:item, Item[params['id']])
+  #     end
+  #
+  #     plug :check_item do |conn|
+  #       if conn.fetch(:item)
+  #         conn
+  #       else
+  #         conn.not_found
+  #       end
+  #     end
+  #
+  #     plug :render do |conn|
+  #       conn.set_response_body(conn.fetch(:item).name)
+  #     end
+  #   end
+  module NotFound
+    # @api private
+    RESPONSE_BODY_STEP_CONFIG_KEY = :not_found_body_step
+
+    # Generates the not-found response
+    #
+    # @return [WebPipe::Conn::Halted]
+    # @see NotFound
+    def not_found
+      set_status(404)
+        .then do |conn|
+          response_body_step = conn.fetch_config(RESPONSE_BODY_STEP_CONFIG_KEY,
+                                                 ->(c) { c.set_response_body('Not found') })
+
+          response_body_step.call(conn)
+        end.halt
+    end
+
+    Conn.include(NotFound)
+  end
+end

--- a/spec/extensions/not_found/not_found_spec.rb
+++ b/spec/extensions/not_found/not_found_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'web_pipe'
+require 'support/conn'
+
+RSpec.describe WebPipe::Conn do
+  before { WebPipe.load_extensions(:not_found) }
+
+  describe '#not_found' do
+    it 'sets 404 status code' do
+      conn = build_conn
+
+      expect(conn.not_found.status).to be(404)
+    end
+
+    it 'halts it' do
+      conn = build_conn
+
+      expect(conn.not_found.halted?).to be(true)
+    end
+
+    context 'when no response body is configured' do
+      it 'sets "Not found" as response body' do
+        conn = build_conn
+
+        expect(conn.not_found.response_body).to eq(['Not found'])
+      end
+    end
+
+    context 'when a step to build the response body is configured' do
+      it 'uses it' do
+        conn = build_conn.add_config(:not_found_body_step,
+                                     ->(c) { c.set_response_body('Nothing here') })
+
+        expect(conn.not_found.response_body).to eq(['Nothing here'])
+      end
+    end
+  end
+end

--- a/spec/support/conn.rb
+++ b/spec/support/conn.rb
@@ -29,6 +29,6 @@ end
 #
 # @param env [Hash]
 # @return Conn [WebPipe::Conn]
-def build_conn(env)
+def build_conn(env = default_env)
   WebPipe::ConnSupport::Builder.call(env)
 end


### PR DESCRIPTION
This extension helps to build a not-found response in a single method
invocation. The `WebPipe::Conn#not_found` method will:

- Set 404 as response status.
- Set 'Not found' as the response body, or instead run a step configured in
`:not_found_body_step` config key.
- Halt the connection struct.

```ruby
require 'web_pipe'
require 'web_pipe/plugs/config'

WebPipe.load_extensions(:params, :not_found)

class ShowItem
  include 'web_pipe'

  plug :config, WebPipe::Plugs::Config.(
    not_found_body_step: ->(conn) { conn.set_response_body('Nothing') }
  )

  plug :fetch_item do |conn|
    conn.add(:item, Item[params['id']])
  end

  plug :check_item do |conn|
    if conn.fetch(:item)
      conn
    else
      conn.not_found
    end
  end

  plug :render do |conn|
    conn.set_response_body(conn.fetch(:item).name)
  end
end
```