### PR TITLE
Allow overriding instance methods from the DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ functions on an immutable struct.
    1. [Sharing data downstream](docs/connection_struct/sharing_data_downstream.md)
    1. [Halting the pipe](docs/connection_struct/halting_the_pipe.md)
    1. [Configuring the connection struct](docs/connection_struct/configuring_the_connection_struct.md)
+1. [Overriding instance methods](docs/overriding_instance_methods.md)
 1. [DSL free usage](docs/dsl_free_usage.md)
 1. [Plugs](docs/plugs.md)
    1. [Config](docs/plugs/config.md)

--- a/docs/overriding_instance_methods.md
+++ b/docs/overriding_instance_methods.md
@@ -1,0 +1,47 @@
+# Overriding instance methods
+
+You can override the included instance methods and use `super` to delegate to
+the `WebPipe`'s implementation.
+
+For instance, you might want to add some behavior to your initializer. However,
+consider that you need to dispatch the arguments that `WebPipe` needs. Example:
+
+```ruby
+class MyApp
+  include WebPipe
+
+  attr_reader :body
+
+  def initialize(body:, **kwargs)
+    @body = body
+    super(**kwargs)
+  end
+
+  plug :render
+
+  private
+
+  def render(conn)
+    conn.set_response_body(body)
+  end
+end
+```
+
+The same goes with any other instance method, like Rack's interface:
+
+```ruby
+class My App
+  include WebPipe
+
+  plug :render
+
+  def render(conn)
+    conn.set_response_body(conn.env['body'])
+  end
+
+  def call(env)
+    env['body'] = 'Hello, world!'
+    super
+  end
+end
+```

--- a/spec/dsl/overriding_instance_methods_spec.rb
+++ b/spec/dsl/overriding_instance_methods_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/conn'
+
+RSpec.describe 'Overriding instance methods' do
+  it 'can define custom initialize and call super' do
+    pipe = Class.new do
+      include WebPipe
+
+      attr_reader :greeting
+
+      def initialize(greeting:, **kwargs)
+        @greeting = greeting
+        super(**kwargs)
+      end
+
+      plug :name
+
+      plug :render
+
+      private
+
+      def name
+        raise NotImplementedError
+      end
+
+      def render(conn)
+        conn.set_response_body(greeting + conn.fetch(:name))
+      end
+    end.new(greeting: 'Hello, ', plugs: { name: ->(conn) { conn.add(:name, 'Alice') } } )
+
+    expect(pipe.call(default_env).last[0]).to eq('Hello, Alice')
+  end
+
+  it 'can define custom pipe methods and call super' do
+    pipe = Class.new do
+      include WebPipe
+
+      plug :render
+
+      def call(env)
+        env['body'] = 'Hello, world!'
+        super(env)
+      end
+
+      private
+
+      def render(conn)
+        conn.set_response_body(conn.env['body'])
+      end
+    end.new
+
+    expect(pipe.call(default_env).last[0]).to eq('Hello, world!')
+  end
+end


### PR DESCRIPTION
If we use `define_method` on the class that includes `WebPipe`, we lose
the possibility for it to call `super` (a new definition would
completely override ours). Instead, we now include a dynamic module.
That goes one level above the class in the ancestor's chain, so `super`
will work as expected.

For instance, someone might want to add some behavior to the initializer.

```ruby
class MyApp
  include WebPipe

  attr_reader :body

  def initialize(body:, **kwargs)
    @body = body
    super(**kwargs)
  end

  plug :render

  private

  def render(conn)
    conn.set_response_body(body)
  end
end
```

The same goes with any other instance method, like Rack's interface:

```ruby
class My App
  include WebPipe

  plug :render

  def render(conn)
    conn.set_response_body(conn.env['body'])
  end

  def call(env)
    env['body'] = 'Hello, world!'
    super
  end
end
```