### PR TITLE
Update hanami-view extension to work with the 2.1 beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gemspec
 
 group :development do
   # TODO: Move to gemspec when hanami-view 2.0 is available
-  gem 'hanami-view', github: 'hanami/view', tag: 'v2.0.0.alpha2'
+  gem 'hanami-view', github: 'hanami/view', tag: 'v2.1.0.beta2'
 end

--- a/lib/web_pipe/conn_support/composition.rb
+++ b/lib/web_pipe/conn_support/composition.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/monads/result'
+require 'dry/monads'
 require 'web_pipe/conn'
 
 module WebPipe
@@ -20,7 +20,7 @@ module WebPipe
         end
       end
 
-      include Dry::Monads::Result::Mixin
+      include Dry::Monads[:result]
 
       attr_reader :operations
 

--- a/lib/web_pipe/extensions/hanami_view/hanami_view/context.rb
+++ b/lib/web_pipe/extensions/hanami_view/hanami_view/context.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'hanami/view'
+
+module WebPipe
+  module HanamiView
+    # Noop context class for Hanami::View used by default.
+    class Context < Hanami::View::Context
+      def initialize(**_kwargs)
+        super()
+      end
+    end
+  end
+end

--- a/lib/web_pipe/extensions/params/params.rb
+++ b/lib/web_pipe/extensions/params/params.rb
@@ -19,7 +19,7 @@ module WebPipe
                 transformation_specs
               end
       transformations = specs.reduce(Transf[:id]) do |acc, t|
-        acc.>>transformation(t)
+        acc >> transformation(t)
       end
 
       Transf[transformations].call(request.params)

--- a/spec/dsl/overriding_instance_methods_spec.rb
+++ b/spec/dsl/overriding_instance_methods_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Overriding instance methods' do
       def render(conn)
         conn.set_response_body(greeting + conn.fetch(:name))
       end
-    end.new(greeting: 'Hello, ', plugs: { name: ->(conn) { conn.add(:name, 'Alice') } } )
+    end.new(greeting: 'Hello, ', plugs: { name: ->(conn) { conn.add(:name, 'Alice') } })
 
     expect(pipe.call(default_env).last[0]).to eq('Hello, Alice')
   end

--- a/spec/extensions/flash/integration/flash_spec.rb
+++ b/spec/extensions/flash/integration/flash_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Using flash' do
     Class.new do
       include WebPipe
 
-      use :session, ::Rack::Session::Cookie, secret: 'secret'
-      use :flash, ::Rack::Flash
+      use :session, Rack::Session::Cookie, secret: 'secret'
+      use :flash, Rack::Flash
 
       plug :add_to_flash
       plug :build_response


### PR DESCRIPTION
`Hanami::View::Context` no longer supports `#with`, as it's [encouraged](https://github.com/hanami/view/pull/223) for a single instance to be used for the whole request.

We use the [same approach as hanami](https://github.com/hanami/hanami/pull/1359), where users can configure a default context class and it's expected to be initialized with keyword arguments. In our case, the default context class is a noop and we expect users to implement it. It can be configured in the `view_context_class` setting, while the initialize options can be created from the connection struct through a lambda configured in the `view_context_options` setting.

Other changes to make CI green

- Use new recommended way to load dry-monad's result type
- Fix rubocop offenses
