### PR TITLE
Use Zeitwerk for autoloading

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    - web_pipe.gemspec
 
 Naming/AccessorMethodName:
   Enabled: false

--- a/docs/dsl_free_usage.md
+++ b/docs/dsl_free_usage.md
@@ -46,7 +46,6 @@ is exactly equivalent to:
 ```ruby
 # config.ru
 require 'web_pipe'
-require 'web_pipe/pipe'
 
 WebPipe.load_extensions(:params)
 

--- a/docs/extensions/container.md
+++ b/docs/extensions/container.md
@@ -15,7 +15,6 @@ are using the container configured in a connection instance.
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 require 'my_container'
 
 WebPipe.load_extensions(:container)

--- a/docs/extensions/dry_schema.md
+++ b/docs/extensions/dry_schema.md
@@ -21,7 +21,6 @@ can be reused through composition by other applications.
 require 'db'
 require 'dry/schema'
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:dry_schema)
 

--- a/docs/extensions/hanami_view.md
+++ b/docs/extensions/hanami_view.md
@@ -43,7 +43,6 @@ However, you can resolve a view from a container if you also use the
 require 'hanami_view'
 require 'my_container'
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:hanami_view, :container)
 
@@ -80,7 +79,6 @@ the view context class:
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:url)
 

--- a/docs/extensions/not_found.md
+++ b/docs/extensions/not_found.md
@@ -10,7 +10,6 @@ invocation. The `WebPipe::Conn#not_found` method will:
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:params, :not_found)
 

--- a/docs/extensions/params.md
+++ b/docs/extensions/params.md
@@ -23,7 +23,6 @@ key:
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:params)
 

--- a/docs/extensions/rails.md
+++ b/docs/extensions/rails.md
@@ -70,8 +70,6 @@ class ApplicationController < ActionController::Base
 end
 
 # app/controllers/articles_index.rb
-require 'web_pipe/plugs/config'
-
 WebPipe.load_extensions(:rails) # You can put it in an initializer
 
 class ArticlesIndex

--- a/docs/extensions/router_params.md
+++ b/docs/extensions/router_params.md
@@ -17,7 +17,6 @@ transformation to the stack.
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 WebPipe.load_extensions(:router_params)
 

--- a/docs/plugging_operations/inspecting_operations.md
+++ b/docs/plugging_operations/inspecting_operations.md
@@ -7,7 +7,6 @@ the `#operations` method:
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/conn_support/builder'
 
 class MyApp
   include WebPipe

--- a/docs/plugs/config.md
+++ b/docs/plugs/config.md
@@ -5,7 +5,6 @@ attribute) to an instance of `WebPipe::Conn`.
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/config'
 
 class MyApp
   include WebPipe

--- a/docs/plugs/content_type.md
+++ b/docs/plugs/content_type.md
@@ -7,7 +7,6 @@ Example:
 
 ```ruby
 require 'web_pipe'
-require 'web_pipe/plugs/content_type'
 
 class MyApp
   include WebPipe

--- a/lib/web_pipe.rb
+++ b/lib/web_pipe.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/extensions"
-require "web_pipe/dsl/builder"
+require "zeitwerk"
 
 # Entry-point for the DSL layer.
 #
@@ -53,6 +53,17 @@ require "web_pipe/dsl/builder"
 #     }
 #   )
 module WebPipe
+  def self.loader
+    Zeitwerk::Loader.for_gem.tap do |loader|
+      loader.ignore(
+        "#{__dir__}/web_pipe/conn_support/errors.rb",
+        "#{__dir__}/web_pipe/extensions"
+      )
+      loader.inflector.inflect("dsl" => "DSL")
+    end
+  end
+  loader.setup
+
   extend Dry::Core::Extensions
 
   # Called via {Module#include}, makes available web_pipe's DSL.

--- a/lib/web_pipe/app.rb
+++ b/lib/web_pipe/app.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn"
-require "web_pipe/conn_support/builder"
-require "web_pipe/conn_support/composition"
+require "dry/monads"
 
 module WebPipe
   # Rack app built from a chain of functions that take and return a

--- a/lib/web_pipe/conn.rb
+++ b/lib/web_pipe/conn.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/struct"
-require "web_pipe/conn_support/types"
 require "web_pipe/conn_support/errors"
-require "web_pipe/conn_support/headers"
 
 module WebPipe
   # Struct and methods about web request and response data.

--- a/lib/web_pipe/conn_support/builder.rb
+++ b/lib/web_pipe/conn_support/builder.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "rack"
-require "web_pipe/conn"
-require "web_pipe/conn_support/headers"
 
 module WebPipe
   module ConnSupport

--- a/lib/web_pipe/conn_support/composition.rb
+++ b/lib/web_pipe/conn_support/composition.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/monads"
-require "web_pipe/conn"
 
 module WebPipe
   module ConnSupport

--- a/lib/web_pipe/dsl/builder.rb
+++ b/lib/web_pipe/dsl/builder.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/dsl/class_context"
-require "web_pipe/dsl/instance_context"
-require "web_pipe/pipe"
-
 module WebPipe
   module DSL
     # @api private

--- a/lib/web_pipe/dsl/instance_context.rb
+++ b/lib/web_pipe/dsl/instance_context.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/pipe"
-
 module WebPipe
   module DSL
     # @api private

--- a/lib/web_pipe/extensions/container/container.rb
+++ b/lib/web_pipe/extensions/container/container.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe"
-
 # :nodoc:
 module WebPipe
   # See the docs for the extension linked from the README.

--- a/lib/web_pipe/extensions/cookies/cookies.rb
+++ b/lib/web_pipe/extensions/cookies/cookies.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe"
 require "rack/utils"
 
 # :nodoc:

--- a/lib/web_pipe/extensions/dry_schema/dry_schema.rb
+++ b/lib/web_pipe/extensions/dry_schema/dry_schema.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe"
-
 WebPipe.load_extensions(:params)
 
 # :nodoc:

--- a/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
+++ b/lib/web_pipe/extensions/dry_schema/plugs/sanitize_params.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/types"
 require "web_pipe/extensions/dry_schema/dry_schema"
 
 module WebPipe

--- a/lib/web_pipe/extensions/flash/flash.rb
+++ b/lib/web_pipe/extensions/flash/flash.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn"
 require "web_pipe/conn_support/errors"
 
 # :nodoc:

--- a/lib/web_pipe/extensions/hanami_view/hanami_view.rb
+++ b/lib/web_pipe/extensions/hanami_view/hanami_view.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/types"
-require "web_pipe/conn"
-require "web_pipe"
 require "web_pipe/extensions/hanami_view/hanami_view/context"
 require "hanami/view"
 

--- a/lib/web_pipe/extensions/params/params.rb
+++ b/lib/web_pipe/extensions/params/params.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/types"
 require "web_pipe/extensions/params/params/transf"
 
 # :nodoc:

--- a/lib/web_pipe/extensions/rails/rails.rb
+++ b/lib/web_pipe/extensions/rails/rails.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn"
-
 # :nodoc:
 module WebPipe
   # See the docs for the extension linked from the README.

--- a/lib/web_pipe/extensions/redirect/redirect.rb
+++ b/lib/web_pipe/extensions/redirect/redirect.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/types"
-
 # :nodoc:
 module WebPipe
   # See the docs for the extension linked from the README.

--- a/lib/web_pipe/extensions/router_params/router_params.rb
+++ b/lib/web_pipe/extensions/router_params/router_params.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe"
-require "web_pipe/types"
-
 WebPipe.load_extensions(:params)
 
 module WebPipe

--- a/lib/web_pipe/extensions/session/session.rb
+++ b/lib/web_pipe/extensions/session/session.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn"
-require "web_pipe/types"
 require "rack"
 
 # :nodoc:

--- a/lib/web_pipe/pipe.rb
+++ b/lib/web_pipe/pipe.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn_support/composition"
-require "web_pipe/app"
-require "web_pipe/plug"
-require "web_pipe/rack_support/middleware_specification"
-require "web_pipe/rack_support/app_with_middlewares"
-require "web_pipe/types"
-
 module WebPipe
   # Composable rack application builder.
   #
@@ -28,8 +21,6 @@ module WebPipe
   #
   # @example
   # # config.ru
-  # require 'web_pipe/pipe'
-  #
   # app = WebPipe::Pipe.new
   #                    .use(:runtime, Rack::Runtime)
   #                    .plug(:content_type) do |conn|

--- a/lib/web_pipe/plug.rb
+++ b/lib/web_pipe/plug.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/struct"
-require "web_pipe/types"
-require "web_pipe/conn_support/composition"
 
 module WebPipe
   # @api private

--- a/lib/web_pipe/rack_support/app_with_middlewares.rb
+++ b/lib/web_pipe/rack_support/app_with_middlewares.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/rack_support/middleware"
 require "rack"
 
 module WebPipe

--- a/lib/web_pipe/rack_support/middleware.rb
+++ b/lib/web_pipe/rack_support/middleware.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/types"
 require "dry/struct"
 
 module WebPipe

--- a/lib/web_pipe/rack_support/middleware_specification.rb
+++ b/lib/web_pipe/rack_support/middleware_specification.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "dry/struct"
-require "web_pipe/rack_support/middleware"
-require "web_pipe/types"
 
 module WebPipe
   module RackSupport

--- a/lib/web_pipe/test_support.rb
+++ b/lib/web_pipe/test_support.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn_support/builder"
 require "rack/mock"
 
 module WebPipe

--- a/spec/extensions/dry_schema/dry_schema_spec.rb
+++ b/spec/extensions/dry_schema/dry_schema_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe"
 
 RSpec.describe WebPipe::Conn do
   before { WebPipe.load_extensions(:dry_schema) }

--- a/spec/extensions/flash/flash_spec.rb
+++ b/spec/extensions/flash/flash_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/conn"
 require "web_pipe/conn_support/errors"
 require "rack-flash"
 

--- a/spec/extensions/flash/integration/flash_spec.rb
+++ b/spec/extensions/flash/integration/flash_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe"
 require "rack/session/cookie"
 require "rack-flash"
 

--- a/spec/extensions/hanami_view/hanami_view_spec.rb
+++ b/spec/extensions/hanami_view/hanami_view_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 require "support/conn"
 require "hanami/view"
 require "hanami/view/context"
-require "web_pipe/conn"
 
 RSpec.describe WebPipe::Conn do
   before do

--- a/spec/extensions/not_found/not_found_spec.rb
+++ b/spec/extensions/not_found/not_found_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe"
 require "support/conn"
 
 RSpec.describe WebPipe::Conn do

--- a/spec/extensions/params/params_spec.rb
+++ b/spec/extensions/params/params_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe"
 require "support/conn"
 
 RSpec.describe WebPipe::Conn do

--- a/spec/extensions/rails/rails_spec.rb
+++ b/spec/extensions/rails/rails_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/conn"
 
 RSpec.describe WebPipe::Conn do
   before do

--- a/spec/extensions/session/session_spec.rb
+++ b/spec/extensions/session/session_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe"
 
 RSpec.describe WebPipe::Conn do
   before { WebPipe.load_extensions(:session) }

--- a/spec/extensions/url/url_spec.rb
+++ b/spec/extensions/url/url_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe"
 require "support/conn"
 
 RSpec.describe WebPipe::Conn do

--- a/spec/support/conn.rb
+++ b/spec/support/conn.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rack"
-require "web_pipe/conn_support/builder"
 
 # Minimal rack's env.
 #

--- a/spec/unit/web_pipe/app_spec.rb
+++ b/spec/unit/web_pipe/app_spec.rb
@@ -2,8 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/conn_support/composition"
-require "web_pipe/app"
 
 RSpec.describe WebPipe::App do
   describe "#call" do

--- a/spec/unit/web_pipe/conn_spec.rb
+++ b/spec/unit/web_pipe/conn_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "web_pipe/conn"
 require "web_pipe/conn_support/errors"
 require "support/conn"
 require "rack"

--- a/spec/unit/web_pipe/conn_support/builder_spec.rb
+++ b/spec/unit/web_pipe/conn_support/builder_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe/conn_support/builder"
-require "web_pipe/conn"
 require "support/conn"
 
 RSpec.describe WebPipe::ConnSupport::Builder do

--- a/spec/unit/web_pipe/conn_support/composition_spec.rb
+++ b/spec/unit/web_pipe/conn_support/composition_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/conn_support/composition"
 
 RSpec.describe WebPipe::ConnSupport::Composition do
   let(:conn) { build_conn(default_env) }

--- a/spec/unit/web_pipe/conn_support/headers_spec.rb
+++ b/spec/unit/web_pipe/conn_support/headers_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/conn_support/headers"
 
 RSpec.describe WebPipe::ConnSupport::Headers do
   describe ".extract" do

--- a/spec/unit/web_pipe/pipe_spec.rb
+++ b/spec/unit/web_pipe/pipe_spec.rb
@@ -3,10 +3,6 @@
 require "spec_helper"
 require "support/conn"
 require "support/middlewares"
-require "web_pipe/pipe"
-require "web_pipe/plugs"
-require "web_pipe/rack_support/middleware"
-require "web_pipe/rack_support/middleware_specification"
 
 RSpec.describe WebPipe::Pipe do
   describe "#plug" do

--- a/spec/unit/web_pipe/plug_spec.rb
+++ b/spec/unit/web_pipe/plug_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe/plug"
 
 RSpec.describe WebPipe::Plug do
   let(:container) do

--- a/spec/unit/web_pipe/plugs/config_spec.rb
+++ b/spec/unit/web_pipe/plugs/config_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/plugs/config"
 
 RSpec.describe WebPipe::Plugs::Config do
   describe ".call" do

--- a/spec/unit/web_pipe/plugs/content_type_spec.rb
+++ b/spec/unit/web_pipe/plugs/content_type_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "support/conn"
-require "web_pipe/plugs/content_type"
 
 RSpec.describe WebPipe::Plugs::ContentType do
   describe ".call" do

--- a/spec/unit/web_pipe/rack/middleware_specification_spec.rb
+++ b/spec/unit/web_pipe/rack/middleware_specification_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe"
-require "web_pipe/rack_support/middleware"
-require "web_pipe/rack_support/middleware_specification"
 require "support/middlewares"
 
 RSpec.describe WebPipe::RackSupport::MiddlewareSpecification do

--- a/spec/unit/web_pipe/test_support_spec.rb
+++ b/spec/unit/web_pipe/test_support_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "web_pipe/test_support"
 
 RSpec.describe WebPipe::TestSupport do
   let(:klass) do

--- a/spec/web_pipe_spec.rb
+++ b/spec/web_pipe_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-require "web_pipe/version"
-
 RSpec.describe WebPipe do
   it "has a version number" do
     expect(WebPipe::VERSION).not_to be nil
+  end
+
+  it "configures loader" do
+    expect do
+      WebPipe.loader.eager_load(force: true)
+    end.not_to raise_error
   end
 end

--- a/web_pipe.gemspec
+++ b/web_pipe.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-struct", "~> 1.0"
   spec.add_runtime_dependency "dry-types", "~> 1.1"
   spec.add_runtime_dependency "rack", "~> 2.0"
+  spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 end


### PR DESCRIPTION
This commit introduces [Zeitwerk](https://github.com/fxn/zeitwerk) as the autoloader for WebPipe.

We eager-load in a test example to ensure the setup is correct.
